### PR TITLE
Reduce and breakout MR processing

### DIFF
--- a/apm/server/rma/server.js
+++ b/apm/server/rma/server.js
@@ -1,30 +1,62 @@
-const minTime = 30000;
-async function runAll() {
+const minTimeShort = 60 * 1000;
+const minTimeMedium = 30 * 60 * 1000;
+const minTimeLong = 3 * 60 * 60 * 1000;
+
+async function runShort() {
   const startTime = new Date();
+
   await incrementalAggregation(PROFILES['1min'], PROVIDERS['errors']);
   await incrementalAggregation(PROFILES['1min'], PROVIDERS['methods']);
   await incrementalAggregation(PROFILES['1min'], PROVIDERS['pubsub']);
   await incrementalAggregation(PROFILES['1min'], PROVIDERS['system']);
+
+  var diff = Date.now() - startTime;
+  // Call the next aggregation max. once in every {minTime} ms
+  if (diff > minTimeShort) {
+    runShort();
+  } else {
+    setTimeout(runShort, minTimeShort - diff);
+  }
+}
+
+async function runMedium() {
+  const startTime = new Date();
+
   await incrementalAggregation(PROFILES['30min'], PROVIDERS['errors']);
   await incrementalAggregation(PROFILES['30min'], PROVIDERS['methods']);
   await incrementalAggregation(PROFILES['30min'], PROVIDERS['pubsub']);
   await incrementalAggregation(PROFILES['30min'], PROVIDERS['system']);
-  await incrementalAggregation(PROFILES['3hour'], PROVIDERS['errors']);
-  await incrementalAggregation(PROFILES['3hour'], PROVIDERS['methods']);
-  await incrementalAggregation(PROFILES['3hour'], PROVIDERS['pubsub']);
-  await incrementalAggregation(PROFILES['3hour'], PROVIDERS['system']);
+
+  var diff = Date.now() - startTime;
+  // Call the next aggregation max. once in every {minTime} ms
+  if (diff > minTimeMedium) {
+    runMedium();
+  } else {
+    setTimeout(runMedium, minTimeMedium - diff);
+  }
+}
+
+async function runLong() {
+  const startTime = new Date();
+
+  await incrementalAggregation(PROFILES['30min'], PROVIDERS['errors']);
+  await incrementalAggregation(PROFILES['30min'], PROVIDERS['methods']);
+  await incrementalAggregation(PROFILES['30min'], PROVIDERS['pubsub']);
+  await incrementalAggregation(PROFILES['30min'], PROVIDERS['system']);
 
   cleanup(startTime);
 
   var diff = Date.now() - startTime;
   // Call the next aggregation max. once in every {minTime} ms
-  if (diff > minTime) {
-    runAll();
+  if (diff > minTimeLong) {
+    runLong();
   } else {
-    setTimeout(runAll, minTime - diff);
+    setTimeout(runLong, minTimeLong - diff);
   }
 }
 
 Meteor.startup(() => {
-  runAll();
+  runShort();
+  runMedium();
+  runLong();
 });


### PR DESCRIPTION
The amount of processing needed for the mongo MR operations is currently way out of hand. I'm running a smallish app with two servers and something under 200 DAL right now, and the MR operations are chewing through ~$50/month worth of CPU processing on AWS after only a few days of stored APM data.

This drops the processing requirement significantly, from some early data down to 20% of what it was before. And I'm guessing this will not significantly affect the real-time data usage, after all how many times do you look at a 3 hour aggregation to understand what happened in the last 3 hours?