### PR TITLE
Fix aggregation bug

### DIFF
--- a/apm/server/rma/server.js
+++ b/apm/server/rma/server.js
@@ -2,17 +2,13 @@ const minTimeShort = 60 * 1000;
 const minTimeMedium = 30 * 60 * 1000;
 const minTimeLong = 3 * 60 * 60 * 1000;
 
-async function runShort(runOnce = false) {
+async function runShort() {
   const startTime = new Date();
 
   await incrementalAggregation(PROFILES['1min'], PROVIDERS['errors']);
   await incrementalAggregation(PROFILES['1min'], PROVIDERS['methods']);
   await incrementalAggregation(PROFILES['1min'], PROVIDERS['pubsub']);
   await incrementalAggregation(PROFILES['1min'], PROVIDERS['system']);
-
-  if (runOnce) {
-    return;
-  }
 
   var diff = Date.now() - startTime;
   // Call the next aggregation max. once in every {minTime} ms
@@ -23,17 +19,13 @@ async function runShort(runOnce = false) {
   }
 }
 
-async function runMedium(runOnce = false) {
+async function runMedium() {
   const startTime = new Date();
 
   await incrementalAggregation(PROFILES['30min'], PROVIDERS['errors']);
   await incrementalAggregation(PROFILES['30min'], PROVIDERS['methods']);
   await incrementalAggregation(PROFILES['30min'], PROVIDERS['pubsub']);
   await incrementalAggregation(PROFILES['30min'], PROVIDERS['system']);
-
-  if (runOnce) {
-    return;
-  }
 
   var diff = Date.now() - startTime;
   // Call the next aggregation max. once in every {minTime} ms
@@ -51,10 +43,6 @@ async function runLong() {
   await incrementalAggregation(PROFILES['3hour'], PROVIDERS['methods']);
   await incrementalAggregation(PROFILES['3hour'], PROVIDERS['pubsub']);
   await incrementalAggregation(PROFILES['3hour'], PROVIDERS['system']);
-
-  // Make to run all the aggregations before we cleanup
-  runShort(true);
-  runMedium(true);
 
   cleanup(startTime);
 

--- a/apm/server/rma/server.js
+++ b/apm/server/rma/server.js
@@ -2,13 +2,17 @@ const minTimeShort = 60 * 1000;
 const minTimeMedium = 30 * 60 * 1000;
 const minTimeLong = 3 * 60 * 60 * 1000;
 
-async function runShort() {
+async function runShort(runOnce = false) {
   const startTime = new Date();
 
   await incrementalAggregation(PROFILES['1min'], PROVIDERS['errors']);
   await incrementalAggregation(PROFILES['1min'], PROVIDERS['methods']);
   await incrementalAggregation(PROFILES['1min'], PROVIDERS['pubsub']);
   await incrementalAggregation(PROFILES['1min'], PROVIDERS['system']);
+
+  if (runOnce) {
+    return;
+  }
 
   var diff = Date.now() - startTime;
   // Call the next aggregation max. once in every {minTime} ms
@@ -19,13 +23,17 @@ async function runShort() {
   }
 }
 
-async function runMedium() {
+async function runMedium(runOnce = false) {
   const startTime = new Date();
 
   await incrementalAggregation(PROFILES['30min'], PROVIDERS['errors']);
   await incrementalAggregation(PROFILES['30min'], PROVIDERS['methods']);
   await incrementalAggregation(PROFILES['30min'], PROVIDERS['pubsub']);
   await incrementalAggregation(PROFILES['30min'], PROVIDERS['system']);
+
+  if (runOnce) {
+    return;
+  }
 
   var diff = Date.now() - startTime;
   // Call the next aggregation max. once in every {minTime} ms
@@ -43,6 +51,10 @@ async function runLong() {
   await incrementalAggregation(PROFILES['3hour'], PROVIDERS['methods']);
   await incrementalAggregation(PROFILES['3hour'], PROVIDERS['pubsub']);
   await incrementalAggregation(PROFILES['3hour'], PROVIDERS['system']);
+
+  // Make to run all the aggregations before we cleanup
+  runShort(true);
+  runMedium(true);
 
   cleanup(startTime);
 

--- a/apm/server/rma/server.js
+++ b/apm/server/rma/server.js
@@ -39,10 +39,10 @@ async function runMedium() {
 async function runLong() {
   const startTime = new Date();
 
-  await incrementalAggregation(PROFILES['30min'], PROVIDERS['errors']);
-  await incrementalAggregation(PROFILES['30min'], PROVIDERS['methods']);
-  await incrementalAggregation(PROFILES['30min'], PROVIDERS['pubsub']);
-  await incrementalAggregation(PROFILES['30min'], PROVIDERS['system']);
+  await incrementalAggregation(PROFILES['3hour'], PROVIDERS['errors']);
+  await incrementalAggregation(PROFILES['3hour'], PROVIDERS['methods']);
+  await incrementalAggregation(PROFILES['3hour'], PROVIDERS['pubsub']);
+  await incrementalAggregation(PROFILES['3hour'], PROVIDERS['system']);
 
   cleanup(startTime);
 


### PR DESCRIPTION
I made a nasty typo in my last commit that aggregated the 30min profile twice and skipped the 3hour. This fixes the bug, and adds another commit to ensure all profiles are run prior to a cleanup.