### PR TITLE
Stagger runShort, runMedium and runLong

### DIFF
--- a/apm/server/rma/server.js
+++ b/apm/server/rma/server.js
@@ -57,6 +57,6 @@ async function runLong() {
 
 Meteor.startup(() => {
   runShort();
-  runMedium();
-  runLong();
+  setTimeout(() => { runMedium(); },2500);
+  setTimeout(() => { runLong(); },5000);
 });


### PR DESCRIPTION
This reduces the load on mongodb/CPU by ensuring that these functions don't all run at the same time. From my tests, each function tends to take less than 2 seconds, so the 2,500ms gap should be enough to help.