### PR TITLE
Provide working MUP deployment template and guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The easiest way to get this server up and running is to use the recommended conf
 
 ### Setup steps
 
-1) Clone this repo and run `npm install`.
+1) Clone this repo and run `meteor npm install`.
 
 2) Copy [`mup-placeholder.js`](mup-placeholder.js) to `mup.js`. Replace the placeholder entries in the configuration with your configuration.
 

--- a/README.md
+++ b/README.md
@@ -1,48 +1,73 @@
 # APM
 
-This project reduces the original Kadira APM to a single Meteor project.
-Most of the original features are working (like Slack alerts), but there is still a lot of work.
-Feel free to contribute!
+This project reduces the original Kadira APM to a single Meteor project and includes template MUP configuration to let you deploy to any remote server.
 
-## Running it
+Most of the original features are working (like Slack alerts), but there is still a lot of work. Feel free to contribute!
 
-A mongo replica set is required!
+## Get up and running with MUP
 
+The easiest way to get this server up and running is to use the recommended configuration with [MUP](https://github.com/zodern/meteor-up).
+
+### Setup steps
+
+1) Clone this repo and run `npm install`.
+
+2) Copy [`mup-placeholder.js`](mup-placeholder.js) to `mup.js`. Replace the placeholder entries in the configuration with your configuration.
+
+3) Server configuration steps you need to verify prior to deployment:
+
+   a) This setup was tested using a server with at least 512MB of RAM.
+
+   b) Allow public access to your server on the following ports: 22, 80, 443, 7007, 11011.
+
+   c) In order for SSL configuration to succeed, you must set setup your DNS to point to your server IP address prior to deployment. Make sure to point both `apm.YOUR_DOMAIN.com` and `apm-engine.YOUR_DOMAIN.com` to the same server IP address.
+
+4) Run `npm run mup-deploy`.
+
+5) Visit your APM UI page at `https://apm.YOUR_DOMAIN.com`. Login with username `admin@admin.com`, password `admin`. **CHANGE YOUR PASSWORD FROM THIS DEFAULT**.
+
+6) In the APM web UI, create a new app and pass the settings to your Meteor app:
+
+`settings.json`
 ```
-cd apm
-meteor npm i
-meteor
+{
+  ...
+  "kadira": {
+    "appId": "YOUR_APM_APP_ID",
+    "appSecret": "YOUR_APM_APP_SECRET",
+    "options": {
+      "endpoint": "https://apm-engine.YOUR_DOMAIN.com"
+    }
+  },
+}
 ```
 
-This opens the following ports:
+7) Re-deploy your Meteor app, and you should see data populating in your APM UI in seconds.
 
-* UI: 3000
-* RMA: 11011
-* API: 7007
+## Server Restarts
 
-## Login
-
-username: admin@admin.com  
-password: admin  
+The custom nginx proxy configuration does not persist through a server restart. There is no current way to hook this into MUP easily, so you will need to run `npx mup deploy` again if you need to restart the server. This should not be a problem with normal operation.
 
 ## Meteor apm settings
-`metricsLifetime` sets the maximum lifetime of the metrics. Old metrics are removed after each aggregation.
-The default value is 604800000 (1000 * 60 * 60 * 24 * 7 ^= 7 days).
+[`metricsLifetime`](settings.json) sets the maximum lifetime of the metrics. Old metrics are removed after each aggregation. The default value is 604800000 (1000 * 60 * 60 * 24 * 7 ^= 7 days).
 
+As a baseline, a current Meteor application with ~500 DAL uses 0.7 GB for 7 days of APM data.
+
+## Configuration details:
+
+If you want to do custom configuration and server setup, here are items to be aware of:
+
+1) A mongo replica set is required. This is set up automatically for you when using the template MUP configuration script.
+
+2) If you are not getting APM data and see a [No 'Access-Control-Allow-Origin' header is present](#14) console error in your Meteor app, this is due to incorrect nginx proxy configuration. To confirm the issue, ssh into your server (`npx mup ssh`) and run `docker exec mup-nginx-proxy cat /etc/nginx/conf.d/default.conf`. Look for the upstream block for `apm-engine.YOUR_DOMAIN.com`, the entry should look like 
 ```
-"metricsLifetime": 604800000
+upstream apm-engine.YOUR_DOMAIN.com {
+    # YOUR_APP
+    server SOME_IP:11011;
+}
 ```
 
-## Meteor client settings
-```
-"kadira": {
-    "appId": "...",
-    "appSecret": "...",
-    "options": {
-        "endpoint": "http://localhost:11011"
-    }
-},
-```
+   If you see port 80 for that setting, the MUP hook that tries to update this port may be failing.
 
 ## Changes to original Kadira
 

--- a/mup-placeholder.js
+++ b/mup-placeholder.js
@@ -1,0 +1,61 @@
+// Copy this file to mup.js and replace placeholders with your info
+module.exports = {
+    servers: {
+        one: {
+            host: 'YOUR_SERVER_IP',
+            username: 'ubuntu',
+            pem: '~/.ssh/id_rsa.YOUR_PRIVATE_SSH_KEY',
+        }
+    },
+
+    app: {
+        name: 'YOUR_APP-apm',
+        path: './apm',
+        servers: {
+            one: {},
+        },
+        buildOptions: {
+            serverOnly: true,
+        },
+        env: {
+            ROOT_URL: 'https://apm.YOUR_DOMAIN.com',
+            MONGO_URL: 'mongodb://localhost/meteor',
+            MONGO_OPLOG_URL: 'mongodb://mongodb/local'
+        },
+        docker: {
+            image: 'abernix/meteord:node-8.4.0-base',
+            args: [
+                '-p 11011:11011', // Open up the engine port
+                '--log-driver json-file', // Without these the Docker log file for Mongo will exhaust disk space
+                '--log-opt max-size=100m',
+                '--log-opt max-file=3',
+            ],
+        },
+        enableUploadProgressBar: true,
+    },
+
+    proxy: {
+        domains: 'apm.YOUR_DOMAIN.com,apm-engine.YOUR_DOMAIN.com',
+        ssl: {
+            forceSSL: true,
+            letsEncryptEmail: 'contact@YOUR_DOMAIN.com',
+        },
+    },
+
+    mongo: {
+        version: '3.4.1',
+        servers: {
+            one: {},
+        },
+    },
+
+    hooks: {
+        // Using remoteCommand would be simpler here, but it was not working
+        'post.meteor.start'(api) {
+            return api.runSSHCommand(
+                api.getConfig().servers.one,
+                "docker exec mup-nginx-proxy sed -i '0,/server.*:80/ s/\\(server.*:\\)80/\\111011/1' /etc/nginx/conf.d/default.conf && docker exec mup-nginx-proxy nginx -s reload",
+            );
+        },
+    },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,7154 @@
+{
+    "name": "meteor-apm-server",
+    "version": "1.0.8",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "mup": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/mup/-/mup-1.4.2.tgz",
+            "integrity": "sha512-bSO1HfP2J2gyUgXzYJCo/ZEEolDoyf7wLiRbGZuYRD/Jq4mbhkO7pwr0QmGvO583bHX4Fs3S0akbkFIfv/M0Fw==",
+            "requires": {
+                "async": "2.6.0",
+                "axios": "0.17.1",
+                "babel-polyfill": "6.26.0",
+                "bluebird": "3.5.1",
+                "boxen": "1.3.0",
+                "chalk": "2.3.0",
+                "debug": "3.1.0",
+                "expand-tilde": "2.0.2",
+                "global-modules": "1.0.0",
+                "joi": "12.0.0",
+                "lodash": "4.17.4",
+                "nodemiral": "1.1.1",
+                "opencollective": "1.0.3",
+                "parse-json": "4.0.0",
+                "random-seed": "0.3.0",
+                "resolve-from": "4.0.0",
+                "shelljs": "0.5.3",
+                "silent-npm-registry-client": "3.0.1",
+                "ssh2": "0.4.15",
+                "tar": "4.3.2",
+                "traverse": "0.6.6",
+                "uuid": "3.2.1",
+                "yargs": "8.0.2"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+                    "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
+                },
+                "acorn-jsx": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+                    "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+                    "requires": {
+                        "acorn": "3.3.0"
+                    },
+                    "dependencies": {
+                        "acorn": {
+                            "version": "3.3.0",
+                            "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                            "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+                        }
+                    }
+                },
+                "ajv": {
+                    "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                    "requires": {
+                        "co": "4.6.0",
+                        "fast-deep-equal": "1.0.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1"
+                    }
+                },
+                "ajv-keywords": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+                    "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+                },
+                "ansi-align": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+                    "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+                    "requires": {
+                        "string-width": "2.1.1"
+                    }
+                },
+                "ansi-escapes": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+                    "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+                },
+                "anymatch": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+                    "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+                    "optional": true,
+                    "requires": {
+                        "micromatch": "2.3.11",
+                        "normalize-path": "2.1.1"
+                    }
+                },
+                "aproba": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+                    "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+                    "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+                    "optional": true,
+                    "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.3"
+                    },
+                    "dependencies": {
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                            "optional": true
+                        },
+                        "readable-stream": {
+                            "version": "2.3.3",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                            "optional": true,
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "1.0.7",
+                                "safe-buffer": "5.1.1",
+                                "string_decoder": "1.0.3",
+                                "util-deprecate": "1.0.2"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                            "optional": true,
+                            "requires": {
+                                "safe-buffer": "5.1.1"
+                            }
+                        }
+                    }
+                },
+                "argparse": {
+                    "version": "1.0.9",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                    "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+                    "requires": {
+                        "sprintf-js": "1.0.3"
+                    }
+                },
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "requires": {
+                        "arr-flatten": "1.1.0"
+                    }
+                },
+                "arr-flatten": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+                    "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+                },
+                "array-find-index": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+                    "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+                },
+                "array-includes": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+                    "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+                    "requires": {
+                        "define-properties": "1.1.2",
+                        "es-abstract": "1.10.0"
+                    }
+                },
+                "array-iterate": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.1.tgz",
+                    "integrity": "sha1-hlv3+K851rCYLGCQKRSsdrwBCPY="
+                },
+                "array-union": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                    "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                    "requires": {
+                        "array-uniq": "1.0.3"
+                    }
+                },
+                "array-uniq": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+                    "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+                },
+                "array-unique": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+                },
+                "arrify": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                    "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                    "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+                },
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                },
+                "assertion-error": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+                    "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+                },
+                "async": {
+                    "version": "2.6.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+                    "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+                    "requires": {
+                        "lodash": "4.17.4"
+                    }
+                },
+                "async-each": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+                    "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+                    "optional": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                    "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+                },
+                "autoprefixer": {
+                    "version": "7.2.5",
+                    "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.5.tgz",
+                    "integrity": "sha512-XqHfo8Ht0VU+T5P+eWEVoXza456KJ4l62BPewu3vpNf3LP9s2+zYXkXBznzYby4XeECXgG3N4i+hGvOhXErZmA==",
+                    "requires": {
+                        "browserslist": "2.11.3",
+                        "caniuse-lite": "1.0.30000792",
+                        "normalize-range": "0.1.2",
+                        "num2fraction": "1.2.2",
+                        "postcss": "6.0.16",
+                        "postcss-value-parser": "3.3.0"
+                    }
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+                },
+                "aws4": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                    "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+                },
+                "axios": {
+                    "version": "0.17.1",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+                    "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+                    "requires": {
+                        "follow-redirects": "1.4.1",
+                        "is-buffer": "1.1.6"
+                    }
+                },
+                "babel-cli": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
+                    "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+                    "requires": {
+                        "babel-core": "6.26.0",
+                        "babel-polyfill": "6.26.0",
+                        "babel-register": "6.26.0",
+                        "babel-runtime": "6.26.0",
+                        "chokidar": "1.7.0",
+                        "commander": "2.13.0",
+                        "convert-source-map": "1.5.1",
+                        "fs-readdir-recursive": "1.1.0",
+                        "glob": "7.1.2",
+                        "lodash": "4.17.4",
+                        "output-file-sync": "1.1.2",
+                        "path-is-absolute": "1.0.1",
+                        "slash": "1.0.0",
+                        "source-map": "0.5.7",
+                        "v8flags": "2.1.1"
+                    }
+                },
+                "babel-code-frame": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+                    "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "esutils": "2.0.2",
+                        "js-tokens": "3.0.2"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                        },
+                        "chalk": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                            "requires": {
+                                "ansi-styles": "2.2.1",
+                                "escape-string-regexp": "1.0.5",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.1",
+                                "supports-color": "2.0.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            }
+                        }
+                    }
+                },
+                "babel-core": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+                    "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+                    "requires": {
+                        "babel-code-frame": "6.26.0",
+                        "babel-generator": "6.26.0",
+                        "babel-helpers": "6.24.1",
+                        "babel-messages": "6.23.0",
+                        "babel-register": "6.26.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0",
+                        "convert-source-map": "1.5.1",
+                        "debug": "2.6.9",
+                        "json5": "0.5.1",
+                        "lodash": "4.17.4",
+                        "minimatch": "3.0.4",
+                        "path-is-absolute": "1.0.1",
+                        "private": "0.1.8",
+                        "slash": "1.0.0",
+                        "source-map": "0.5.7"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.6.9",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        }
+                    }
+                },
+                "babel-eslint": {
+                    "version": "7.2.3",
+                    "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
+                    "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+                    "requires": {
+                        "babel-code-frame": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0"
+                    }
+                },
+                "babel-generator": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+                    "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+                    "requires": {
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "detect-indent": "4.0.0",
+                        "jsesc": "1.3.0",
+                        "lodash": "4.17.4",
+                        "source-map": "0.5.7",
+                        "trim-right": "1.0.1"
+                    }
+                },
+                "babel-helper-bindify-decorators": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
+                    "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-builder-binary-assignment-operator-visitor": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+                    "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+                    "requires": {
+                        "babel-helper-explode-assignable-expression": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-call-delegate": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+                    "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+                    "requires": {
+                        "babel-helper-hoist-variables": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-define-map": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+                    "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+                    "requires": {
+                        "babel-helper-function-name": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "lodash": "4.17.4"
+                    }
+                },
+                "babel-helper-explode-assignable-expression": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+                    "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-explode-class": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
+                    "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+                    "requires": {
+                        "babel-helper-bindify-decorators": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-function-name": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+                    "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+                    "requires": {
+                        "babel-helper-get-function-arity": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-get-function-arity": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+                    "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-hoist-variables": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+                    "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-optimise-call-expression": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+                    "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-regex": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+                    "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "lodash": "4.17.4"
+                    }
+                },
+                "babel-helper-remap-async-to-generator": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+                    "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+                    "requires": {
+                        "babel-helper-function-name": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-replace-supers": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+                    "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+                    "requires": {
+                        "babel-helper-optimise-call-expression": "6.24.1",
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helpers": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+                    "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0"
+                    }
+                },
+                "babel-messages": {
+                    "version": "6.23.0",
+                    "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                    "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-check-es2015-constants": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+                    "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-istanbul": {
+                    "version": "4.1.5",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
+                    "integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
+                    "requires": {
+                        "find-up": "2.1.0",
+                        "istanbul-lib-instrument": "1.9.1",
+                        "test-exclude": "4.1.1"
+                    }
+                },
+                "babel-plugin-syntax-async-functions": {
+                    "version": "6.13.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+                    "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+                },
+                "babel-plugin-syntax-async-generators": {
+                    "version": "6.13.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+                    "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+                },
+                "babel-plugin-syntax-class-properties": {
+                    "version": "6.13.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+                    "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+                },
+                "babel-plugin-syntax-decorators": {
+                    "version": "6.13.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+                    "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
+                },
+                "babel-plugin-syntax-dynamic-import": {
+                    "version": "6.18.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+                    "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+                },
+                "babel-plugin-syntax-exponentiation-operator": {
+                    "version": "6.13.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+                    "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+                },
+                "babel-plugin-syntax-object-rest-spread": {
+                    "version": "6.13.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+                    "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+                },
+                "babel-plugin-syntax-trailing-function-commas": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+                    "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+                },
+                "babel-plugin-transform-async-generator-functions": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+                    "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+                    "requires": {
+                        "babel-helper-remap-async-to-generator": "6.24.1",
+                        "babel-plugin-syntax-async-generators": "6.13.0",
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-async-to-generator": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+                    "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+                    "requires": {
+                        "babel-helper-remap-async-to-generator": "6.24.1",
+                        "babel-plugin-syntax-async-functions": "6.13.0",
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-class-properties": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+                    "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+                    "requires": {
+                        "babel-helper-function-name": "6.24.1",
+                        "babel-plugin-syntax-class-properties": "6.13.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-decorators": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
+                    "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+                    "requires": {
+                        "babel-helper-explode-class": "6.24.1",
+                        "babel-plugin-syntax-decorators": "6.13.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-arrow-functions": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+                    "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-block-scoped-functions": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+                    "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-block-scoping": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+                    "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "lodash": "4.17.4"
+                    }
+                },
+                "babel-plugin-transform-es2015-classes": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+                    "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+                    "requires": {
+                        "babel-helper-define-map": "6.26.0",
+                        "babel-helper-function-name": "6.24.1",
+                        "babel-helper-optimise-call-expression": "6.24.1",
+                        "babel-helper-replace-supers": "6.24.1",
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-computed-properties": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+                    "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-destructuring": {
+                    "version": "6.23.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+                    "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-duplicate-keys": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+                    "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-for-of": {
+                    "version": "6.23.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+                    "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-function-name": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+                    "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+                    "requires": {
+                        "babel-helper-function-name": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-literals": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+                    "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-modules-amd": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+                    "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+                    "requires": {
+                        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-modules-commonjs": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+                    "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+                    "requires": {
+                        "babel-plugin-transform-strict-mode": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-modules-systemjs": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+                    "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+                    "requires": {
+                        "babel-helper-hoist-variables": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-modules-umd": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+                    "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+                    "requires": {
+                        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-object-super": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+                    "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+                    "requires": {
+                        "babel-helper-replace-supers": "6.24.1",
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-parameters": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+                    "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+                    "requires": {
+                        "babel-helper-call-delegate": "6.24.1",
+                        "babel-helper-get-function-arity": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-shorthand-properties": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+                    "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-spread": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+                    "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-sticky-regex": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+                    "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+                    "requires": {
+                        "babel-helper-regex": "6.26.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-template-literals": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+                    "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-typeof-symbol": {
+                    "version": "6.23.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+                    "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-unicode-regex": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+                    "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+                    "requires": {
+                        "babel-helper-regex": "6.26.0",
+                        "babel-runtime": "6.26.0",
+                        "regexpu-core": "2.0.0"
+                    }
+                },
+                "babel-plugin-transform-exponentiation-operator": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+                    "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+                    "requires": {
+                        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+                        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-object-rest-spread": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+                    "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+                    "requires": {
+                        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-regenerator": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+                    "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+                    "requires": {
+                        "regenerator-transform": "0.10.1"
+                    }
+                },
+                "babel-plugin-transform-strict-mode": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+                    "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-polyfill": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+                    "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "core-js": "2.5.3",
+                        "regenerator-runtime": "0.10.5"
+                    }
+                },
+                "babel-preset-es2015": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+                    "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+                    "requires": {
+                        "babel-plugin-check-es2015-constants": "6.22.0",
+                        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+                        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+                        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+                        "babel-plugin-transform-es2015-classes": "6.24.1",
+                        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+                        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+                        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+                        "babel-plugin-transform-es2015-for-of": "6.23.0",
+                        "babel-plugin-transform-es2015-function-name": "6.24.1",
+                        "babel-plugin-transform-es2015-literals": "6.22.0",
+                        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+                        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+                        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+                        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+                        "babel-plugin-transform-es2015-object-super": "6.24.1",
+                        "babel-plugin-transform-es2015-parameters": "6.24.1",
+                        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+                        "babel-plugin-transform-es2015-spread": "6.22.0",
+                        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+                        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+                        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+                        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+                        "babel-plugin-transform-regenerator": "6.26.0"
+                    }
+                },
+                "babel-preset-es2016": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-preset-es2016/-/babel-preset-es2016-6.24.1.tgz",
+                    "integrity": "sha1-+QC/k+LrwNJ235uKtZck6/2Vn4s=",
+                    "requires": {
+                        "babel-plugin-transform-exponentiation-operator": "6.24.1"
+                    }
+                },
+                "babel-preset-es2017": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-preset-es2017/-/babel-preset-es2017-6.24.1.tgz",
+                    "integrity": "sha1-WXvq37n38gi8/YoS6bKym4svFNE=",
+                    "requires": {
+                        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+                        "babel-plugin-transform-async-to-generator": "6.24.1"
+                    }
+                },
+                "babel-preset-stage-2": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
+                    "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+                    "requires": {
+                        "babel-plugin-syntax-dynamic-import": "6.18.0",
+                        "babel-plugin-transform-class-properties": "6.24.1",
+                        "babel-plugin-transform-decorators": "6.24.1",
+                        "babel-preset-stage-3": "6.24.1"
+                    }
+                },
+                "babel-preset-stage-3": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
+                    "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+                    "requires": {
+                        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+                        "babel-plugin-transform-async-generator-functions": "6.24.1",
+                        "babel-plugin-transform-async-to-generator": "6.24.1",
+                        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+                        "babel-plugin-transform-object-rest-spread": "6.26.0"
+                    }
+                },
+                "babel-register": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+                    "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+                    "requires": {
+                        "babel-core": "6.26.0",
+                        "babel-runtime": "6.26.0",
+                        "core-js": "2.5.3",
+                        "home-or-tmp": "2.0.0",
+                        "lodash": "4.17.4",
+                        "mkdirp": "0.5.1",
+                        "source-map-support": "0.4.18"
+                    }
+                },
+                "babel-runtime": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+                    "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+                    "requires": {
+                        "core-js": "2.5.3",
+                        "regenerator-runtime": "0.11.1"
+                    },
+                    "dependencies": {
+                        "regenerator-runtime": {
+                            "version": "0.11.1",
+                            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+                            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+                        }
+                    }
+                },
+                "babel-template": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+                    "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0",
+                        "lodash": "4.17.4"
+                    }
+                },
+                "babel-traverse": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+                    "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+                    "requires": {
+                        "babel-code-frame": "6.26.0",
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0",
+                        "debug": "2.6.9",
+                        "globals": "9.18.0",
+                        "invariant": "2.2.2",
+                        "lodash": "4.17.4"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.6.9",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        }
+                    }
+                },
+                "babel-types": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+                    "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "esutils": "2.0.2",
+                        "lodash": "4.17.4",
+                        "to-fast-properties": "1.0.3"
+                    }
+                },
+                "babylon": {
+                    "version": "6.18.0",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+                    "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+                },
+                "bail": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
+                    "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q="
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                    "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "binary-extensions": {
+                    "version": "1.11.0",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+                    "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+                    "optional": true
+                },
+                "bluebird": {
+                    "version": "3.5.1",
+                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+                    "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+                },
+                "boom": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+                    "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+                    "requires": {
+                        "hoek": "4.2.0"
+                    }
+                },
+                "boxen": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+                    "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
+                    "requires": {
+                        "ansi-align": "2.0.0",
+                        "camelcase": "4.1.0",
+                        "chalk": "2.3.0",
+                        "cli-boxes": "1.0.0",
+                        "string-width": "2.1.1",
+                        "term-size": "1.2.0",
+                        "widest-line": "2.0.0"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.8",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                    "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "1.8.5",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                    "requires": {
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
+                    }
+                },
+                "browser-stdout": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+                    "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+                },
+                "browserslist": {
+                    "version": "2.11.3",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+                    "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+                    "requires": {
+                        "caniuse-lite": "1.0.30000792",
+                        "electron-to-chromium": "1.3.31"
+                    }
+                },
+                "build": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/build/-/build-0.1.4.tgz",
+                    "integrity": "sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=",
+                    "requires": {
+                        "cssmin": "0.3.2",
+                        "jsmin": "1.0.1",
+                        "jxLoader": "0.1.1",
+                        "moo-server": "1.3.0",
+                        "promised-io": "0.3.5",
+                        "timespan": "2.3.0",
+                        "uglify-js": "1.3.5",
+                        "walker": "1.0.7",
+                        "winston": "2.4.0",
+                        "wrench": "1.3.9"
+                    }
+                },
+                "builtin-modules": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                    "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+                },
+                "builtins": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+                    "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
+                },
+                "caller-path": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+                    "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+                    "requires": {
+                        "callsites": "0.2.0"
+                    }
+                },
+                "callsites": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+                    "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+                },
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+                },
+                "camelcase-keys": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+                    "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+                    "requires": {
+                        "camelcase": "4.1.0",
+                        "map-obj": "2.0.0",
+                        "quick-lru": "1.1.0"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30000792",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
+                    "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI="
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+                },
+                "ccount": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
+                    "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok="
+                },
+                "chai": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+                    "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+                    "requires": {
+                        "assertion-error": "1.1.0",
+                        "check-error": "1.0.2",
+                        "deep-eql": "3.0.1",
+                        "get-func-name": "2.0.0",
+                        "pathval": "1.1.0",
+                        "type-detect": "4.0.7"
+                    }
+                },
+                "chai-string": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.4.0.tgz",
+                    "integrity": "sha1-NZFAwFHTak5LGl/GuRAVL0OKjUk="
+                },
+                "chalk": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
+                    },
+                    "dependencies": {
+                        "ansi-styles": {
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                            "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                            "requires": {
+                                "color-convert": "1.9.1"
+                            }
+                        },
+                        "supports-color": {
+                            "version": "4.5.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+                            "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+                            "requires": {
+                                "has-flag": "2.0.0"
+                            }
+                        }
+                    }
+                },
+                "character-entities": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
+                    "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco="
+                },
+                "character-entities-html4": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.1.tgz",
+                    "integrity": "sha1-NZoqSg9+KdPcKsmb2+Ie45Q46lA="
+                },
+                "character-entities-legacy": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
+                    "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8="
+                },
+                "character-reference-invalid": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
+                    "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw="
+                },
+                "chardet": {
+                    "version": "0.4.2",
+                    "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+                    "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+                },
+                "check-error": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+                    "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+                },
+                "chokidar": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+                    "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+                    "optional": true,
+                    "requires": {
+                        "anymatch": "1.3.2",
+                        "async-each": "1.0.1",
+                        "glob-parent": "2.0.0",
+                        "inherits": "2.0.3",
+                        "is-binary-path": "1.0.1",
+                        "is-glob": "2.0.1",
+                        "path-is-absolute": "1.0.1",
+                        "readdirp": "2.1.0"
+                    }
+                },
+                "chownr": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+                    "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+                },
+                "circular-json": {
+                    "version": "0.3.3",
+                    "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+                    "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+                },
+                "cli-boxes": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+                    "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+                },
+                "cli-cursor": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+                    "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+                    "requires": {
+                        "restore-cursor": "2.0.0"
+                    }
+                },
+                "cli-width": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+                    "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wrap-ansi": "2.1.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                            "requires": {
+                                "number-is-nan": "1.0.1"
+                            }
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "requires": {
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            }
+                        }
+                    }
+                },
+                "clone-regexp": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.0.tgz",
+                    "integrity": "sha1-6uCiQT9VwJQvgYwin+/OhF1/Oxw=",
+                    "requires": {
+                        "is-regexp": "1.0.0",
+                        "is-supported-regexp-flag": "1.0.0"
+                    }
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                    "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+                },
+                "collapse-white-space": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
+                    "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw="
+                },
+                "color-convert": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+                    "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+                },
+                "colors": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+                    "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+                },
+                "combined-stream": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                    "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                },
+                "commander": {
+                    "version": "2.13.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+                    "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                },
+                "concat-stream": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+                    "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.3",
+                        "typedarray": "0.0.6"
+                    },
+                    "dependencies": {
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                        },
+                        "readable-stream": {
+                            "version": "2.3.3",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "1.0.7",
+                                "safe-buffer": "5.1.1",
+                                "string_decoder": "1.0.3",
+                                "util-deprecate": "1.0.2"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                            "requires": {
+                                "safe-buffer": "5.1.1"
+                            }
+                        }
+                    }
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+                },
+                "convert-source-map": {
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+                    "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+                },
+                "core-js": {
+                    "version": "2.5.3",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+                    "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                },
+                "cosmiconfig": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+                    "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+                    "requires": {
+                        "is-directory": "0.3.1",
+                        "js-yaml": "3.10.0",
+                        "parse-json": "3.0.0",
+                        "require-from-string": "2.0.1"
+                    },
+                    "dependencies": {
+                        "parse-json": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+                            "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+                            "requires": {
+                                "error-ex": "1.3.1"
+                            }
+                        }
+                    }
+                },
+                "cross-env": {
+                    "version": "5.1.3",
+                    "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.3.tgz",
+                    "integrity": "sha512-UOokgwvDzCT0mqRSLEkJzUhYXB1vK3E5UgDrD41QiXsm9UetcW2rCGHYz/O3p873lMJ1VZbFCF9Izkwh7nYR5A==",
+                    "requires": {
+                        "cross-spawn": "5.1.0",
+                        "is-windows": "1.0.1"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "requires": {
+                        "lru-cache": "4.1.1",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.0"
+                    }
+                },
+                "cryptiles": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+                    "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+                    "requires": {
+                        "boom": "5.2.0"
+                    },
+                    "dependencies": {
+                        "boom": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                            "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                            "requires": {
+                                "hoek": "4.2.0"
+                            }
+                        }
+                    }
+                },
+                "cssmin": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/cssmin/-/cssmin-0.3.2.tgz",
+                    "integrity": "sha1-3c5MVHtRCuDVlKjx+/iq+OLFwA0="
+                },
+                "currently-unhandled": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+                    "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+                    "requires": {
+                        "array-find-index": "1.0.2"
+                    }
+                },
+                "cycle": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+                    "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                    "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "decamelize": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                    "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+                },
+                "decamelize-keys": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+                    "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+                    "requires": {
+                        "decamelize": "1.2.0",
+                        "map-obj": "1.0.1"
+                    },
+                    "dependencies": {
+                        "map-obj": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+                        }
+                    }
+                },
+                "deep-eql": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+                    "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+                    "requires": {
+                        "type-detect": "4.0.7"
+                    }
+                },
+                "deep-is": {
+                    "version": "0.1.3",
+                    "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                    "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+                },
+                "define-properties": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+                    "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+                    "requires": {
+                        "foreach": "2.0.5",
+                        "object-keys": "1.0.11"
+                    }
+                },
+                "del": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+                    "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+                    "requires": {
+                        "globby": "5.0.0",
+                        "is-path-cwd": "1.0.0",
+                        "is-path-in-cwd": "1.0.0",
+                        "object-assign": "4.1.1",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "rimraf": "2.6.2"
+                    }
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                    "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                    "optional": true
+                },
+                "detect-indent": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+                    "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+                    "requires": {
+                        "repeating": "2.0.1"
+                    }
+                },
+                "diff": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+                    "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+                },
+                "dir-glob": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+                    "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+                    "requires": {
+                        "arrify": "1.0.1",
+                        "path-type": "3.0.0"
+                    },
+                    "dependencies": {
+                        "path-type": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                            "requires": {
+                                "pify": "3.0.0"
+                            }
+                        },
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+                        }
+                    }
+                },
+                "doctrine": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+                    "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+                    "requires": {
+                        "esutils": "2.0.2"
+                    }
+                },
+                "dom-serializer": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                    "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+                    "requires": {
+                        "domelementtype": "1.1.3",
+                        "entities": "1.1.1"
+                    },
+                    "dependencies": {
+                        "domelementtype": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                            "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+                        }
+                    }
+                },
+                "domelementtype": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                    "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+                },
+                "domhandler": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+                    "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+                    "requires": {
+                        "domelementtype": "1.3.0"
+                    }
+                },
+                "domutils": {
+                    "version": "1.6.2",
+                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz",
+                    "integrity": "sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=",
+                    "requires": {
+                        "dom-serializer": "0.1.0",
+                        "domelementtype": "1.3.0"
+                    }
+                },
+                "dot-prop": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+                    "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+                    "requires": {
+                        "is-obj": "1.0.1"
+                    }
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                    "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "ejs": {
+                    "version": "0.8.8",
+                    "resolved": "https://registry.npmjs.org/ejs/-/ejs-0.8.8.tgz",
+                    "integrity": "sha1-/9xW3MNdApJt1QrRNDm7xUBh1Zg="
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.31",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
+                    "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA=="
+                },
+                "encoding": {
+                    "version": "0.1.12",
+                    "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                    "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+                    "requires": {
+                        "iconv-lite": "0.4.19"
+                    }
+                },
+                "entities": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                    "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+                },
+                "error-ex": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                    "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+                    "requires": {
+                        "is-arrayish": "0.2.1"
+                    }
+                },
+                "es-abstract": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+                    "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+                    "requires": {
+                        "es-to-primitive": "1.1.1",
+                        "function-bind": "1.1.1",
+                        "has": "1.0.1",
+                        "is-callable": "1.1.3",
+                        "is-regex": "1.0.4"
+                    }
+                },
+                "es-to-primitive": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+                    "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+                    "requires": {
+                        "is-callable": "1.1.3",
+                        "is-date-object": "1.0.1",
+                        "is-symbol": "1.0.1"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+                },
+                "eslint": {
+                    "version": "4.17.0",
+                    "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.17.0.tgz",
+                    "integrity": "sha512-AyxBUCANU/o/xC0ijGMKavo5Ls3oK6xykiOITlMdjFjrKOsqLrA7Nf5cnrDgcKrHzBirclAZt63XO7YZlVUPwA==",
+                    "requires": {
+                        "ajv": "5.5.2",
+                        "babel-code-frame": "6.26.0",
+                        "chalk": "2.3.0",
+                        "concat-stream": "1.6.0",
+                        "cross-spawn": "5.1.0",
+                        "debug": "3.1.0",
+                        "doctrine": "2.1.0",
+                        "eslint-scope": "3.7.1",
+                        "eslint-visitor-keys": "1.0.0",
+                        "espree": "3.5.3",
+                        "esquery": "1.0.0",
+                        "esutils": "2.0.2",
+                        "file-entry-cache": "2.0.0",
+                        "functional-red-black-tree": "1.0.1",
+                        "glob": "7.1.2",
+                        "globals": "11.3.0",
+                        "ignore": "3.3.7",
+                        "imurmurhash": "0.1.4",
+                        "inquirer": "3.0.6",
+                        "is-resolvable": "1.1.0",
+                        "js-yaml": "3.10.0",
+                        "json-stable-stringify-without-jsonify": "1.0.1",
+                        "levn": "0.3.0",
+                        "lodash": "4.17.4",
+                        "minimatch": "3.0.4",
+                        "mkdirp": "0.5.1",
+                        "natural-compare": "1.4.0",
+                        "optionator": "0.8.2",
+                        "path-is-inside": "1.0.2",
+                        "pluralize": "7.0.0",
+                        "progress": "2.0.0",
+                        "require-uncached": "1.0.3",
+                        "semver": "5.5.0",
+                        "strip-ansi": "4.0.0",
+                        "strip-json-comments": "2.0.1",
+                        "table": "4.0.2",
+                        "text-table": "0.2.0"
+                    },
+                    "dependencies": {
+                        "globals": {
+                            "version": "11.3.0",
+                            "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+                            "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw=="
+                        },
+                        "progress": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+                            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+                        }
+                    }
+                },
+                "eslint-config-es": {
+                    "version": "0.8.12",
+                    "resolved": "https://registry.npmjs.org/eslint-config-es/-/eslint-config-es-0.8.12.tgz",
+                    "integrity": "sha512-r7nN8/NzRZTuLhWoa6t+HSo1rdfvkVcHYs5QRBQov33AJi5RNXWAvKhr80iuPWwluCv3oDQX4X+ooYPrVvvbXw==",
+                    "requires": {
+                        "array-includes": "3.0.3"
+                    }
+                },
+                "eslint-plugin-babel": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-4.1.2.tgz",
+                    "integrity": "sha1-eSAqDjV1fdkngJGbIzbx+i/lPB4="
+                },
+                "eslint-plugin-markdown": {
+                    "version": "1.0.0-beta.7",
+                    "resolved": "https://registry.npmjs.org/eslint-plugin-markdown/-/eslint-plugin-markdown-1.0.0-beta.7.tgz",
+                    "integrity": "sha1-Euc6QSfEpLedlm+fR1hR3Q949+c=",
+                    "requires": {
+                        "object-assign": "4.1.1",
+                        "remark-parse": "3.0.1",
+                        "unified": "6.1.6"
+                    }
+                },
+                "eslint-scope": {
+                    "version": "3.7.1",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+                    "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+                    "requires": {
+                        "esrecurse": "4.2.0",
+                        "estraverse": "4.2.0"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+                    "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+                },
+                "espree": {
+                    "version": "3.5.3",
+                    "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
+                    "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+                    "requires": {
+                        "acorn": "5.4.1",
+                        "acorn-jsx": "3.0.1"
+                    }
+                },
+                "esprima": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+                    "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+                },
+                "esquery": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+                    "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+                    "requires": {
+                        "estraverse": "4.2.0"
+                    }
+                },
+                "esrecurse": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+                    "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+                    "requires": {
+                        "estraverse": "4.2.0",
+                        "object-assign": "4.1.1"
+                    }
+                },
+                "estraverse": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+                    "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+                },
+                "esutils": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                    "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                },
+                "execa": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                    "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+                    "requires": {
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                    }
+                },
+                "execall": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
+                    "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+                    "requires": {
+                        "clone-regexp": "1.0.0"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                    "requires": {
+                        "is-posix-bracket": "0.1.1"
+                    }
+                },
+                "expand-range": {
+                    "version": "1.8.2",
+                    "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                    "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+                    "requires": {
+                        "fill-range": "2.2.3"
+                    }
+                },
+                "expand-tilde": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+                    "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+                    "requires": {
+                        "homedir-polyfill": "1.0.1"
+                    }
+                },
+                "extend": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                    "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+                },
+                "external-editor": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+                    "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+                    "requires": {
+                        "chardet": "0.4.2",
+                        "iconv-lite": "0.4.19",
+                        "tmp": "0.0.33"
+                    }
+                },
+                "extglob": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "extsprintf": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+                    "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+                },
+                "eyes": {
+                    "version": "0.1.8",
+                    "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+                    "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+                },
+                "fast-deep-equal": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+                    "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+                },
+                "fast-json-stable-stringify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+                    "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+                },
+                "fast-levenshtein": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+                    "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+                },
+                "figures": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+                    "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+                    "requires": {
+                        "escape-string-regexp": "1.0.5"
+                    }
+                },
+                "file-entry-cache": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+                    "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+                    "requires": {
+                        "flat-cache": "1.3.0",
+                        "object-assign": "4.1.1"
+                    }
+                },
+                "filename-regex": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+                    "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+                },
+                "fill-range": {
+                    "version": "2.2.3",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                    "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                    "requires": {
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "1.1.7",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.6.1"
+                    }
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "requires": {
+                        "locate-path": "2.0.0"
+                    }
+                },
+                "flat-cache": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+                    "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+                    "requires": {
+                        "circular-json": "0.3.3",
+                        "del": "2.2.2",
+                        "graceful-fs": "4.1.11",
+                        "write": "0.2.1"
+                    }
+                },
+                "follow-redirects": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+                    "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+                    "requires": {
+                        "debug": "3.1.0"
+                    }
+                },
+                "for-in": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+                    "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+                },
+                "for-own": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                    "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+                    "requires": {
+                        "for-in": "1.0.2"
+                    }
+                },
+                "foreach": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+                    "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                    "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+                },
+                "form-data": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+                    "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.17"
+                    }
+                },
+                "formatio": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+                    "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+                    "requires": {
+                        "samsam": "1.3.0"
+                    }
+                },
+                "fs-minipass": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+                    "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+                    "requires": {
+                        "minipass": "2.2.1"
+                    }
+                },
+                "fs-readdir-recursive": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+                    "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+                },
+                "function-bind": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+                    "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+                },
+                "functional-red-black-tree": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+                    "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+                    "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+                    "optional": true,
+                    "requires": {
+                        "aproba": "1.2.0",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                            "optional": true,
+                            "requires": {
+                                "number-is-nan": "1.0.1"
+                            }
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "optional": true,
+                            "requires": {
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            }
+                        }
+                    }
+                },
+                "get-caller-file": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+                    "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+                },
+                "get-func-name": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+                    "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+                },
+                "get-stdin": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+                    "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                    "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    }
+                },
+                "gfm-code-block-regex": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/gfm-code-block-regex/-/gfm-code-block-regex-1.0.0.tgz",
+                    "integrity": "sha1-u4PH1ihOa1ty+gIZilisDSViFdI="
+                },
+                "gfm-code-blocks": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/gfm-code-blocks/-/gfm-code-blocks-1.0.0.tgz",
+                    "integrity": "sha1-YU0hBZuETGu8nViMCJslxOi8zw0=",
+                    "requires": {
+                        "gfm-code-block-regex": "1.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "glob-base": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                    "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+                    "requires": {
+                        "glob-parent": "2.0.0",
+                        "is-glob": "2.0.1"
+                    }
+                },
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "requires": {
+                        "is-glob": "2.0.1"
+                    }
+                },
+                "global-modules": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+                    "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+                    "requires": {
+                        "global-prefix": "1.0.2",
+                        "is-windows": "1.0.1",
+                        "resolve-dir": "1.0.1"
+                    }
+                },
+                "global-prefix": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+                    "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+                    "requires": {
+                        "expand-tilde": "2.0.2",
+                        "homedir-polyfill": "1.0.1",
+                        "ini": "1.3.5",
+                        "is-windows": "1.0.1",
+                        "which": "1.3.0"
+                    }
+                },
+                "globals": {
+                    "version": "9.18.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                    "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+                },
+                "globby": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+                    "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+                    "requires": {
+                        "array-union": "1.0.2",
+                        "arrify": "1.0.1",
+                        "glob": "7.1.2",
+                        "object-assign": "4.1.1",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "globjoin": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+                    "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM="
+                },
+                "gonzales-pe": {
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.3.tgz",
+                    "integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
+                    "requires": {
+                        "minimist": "1.1.3"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+                            "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag="
+                        }
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+                },
+                "graceful-readlink": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                    "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+                },
+                "growl": {
+                    "version": "1.9.2",
+                    "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+                    "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
+                },
+                "har-schema": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+                    "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+                },
+                "har-validator": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+                    "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+                    "requires": {
+                        "ajv": "5.5.2",
+                        "har-schema": "2.0.0"
+                    }
+                },
+                "has": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+                    "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+                    "requires": {
+                        "function-bind": "1.1.1"
+                    }
+                },
+                "has-ansi": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                    "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                        }
+                    }
+                },
+                "has-flag": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+                    "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+                    "optional": true
+                },
+                "hawk": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+                    "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+                    "requires": {
+                        "boom": "4.3.1",
+                        "cryptiles": "3.1.2",
+                        "hoek": "4.2.0",
+                        "sntp": "2.1.0"
+                    }
+                },
+                "he": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+                    "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+                },
+                "hoek": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+                    "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+                },
+                "home-or-tmp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+                    "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "homedir-polyfill": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+                    "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+                    "requires": {
+                        "parse-passwd": "1.0.0"
+                    }
+                },
+                "hosted-git-info": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+                    "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+                },
+                "html-tags": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
+                    "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos="
+                },
+                "htmlparser2": {
+                    "version": "3.9.2",
+                    "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+                    "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+                    "requires": {
+                        "domelementtype": "1.3.0",
+                        "domhandler": "2.4.1",
+                        "domutils": "1.6.2",
+                        "entities": "1.1.1",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.3"
+                    },
+                    "dependencies": {
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                        },
+                        "readable-stream": {
+                            "version": "2.3.3",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "1.0.7",
+                                "safe-buffer": "5.1.1",
+                                "string_decoder": "1.0.3",
+                                "util-deprecate": "1.0.2"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                            "requires": {
+                                "safe-buffer": "5.1.1"
+                            }
+                        }
+                    }
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.13.1"
+                    }
+                },
+                "iconv-lite": {
+                    "version": "0.4.19",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+                    "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+                },
+                "ignore": {
+                    "version": "3.3.7",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+                    "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+                },
+                "imurmurhash": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                    "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+                },
+                "indent-string": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+                    "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+                },
+                "indexes-of": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+                    "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+                    "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+                },
+                "inquirer": {
+                    "version": "3.0.6",
+                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
+                    "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
+                    "requires": {
+                        "ansi-escapes": "1.4.0",
+                        "chalk": "1.1.3",
+                        "cli-cursor": "2.1.0",
+                        "cli-width": "2.2.0",
+                        "external-editor": "2.1.0",
+                        "figures": "2.0.0",
+                        "lodash": "4.17.4",
+                        "mute-stream": "0.0.7",
+                        "run-async": "2.3.0",
+                        "rx": "4.1.0",
+                        "string-width": "2.1.1",
+                        "strip-ansi": "3.0.1",
+                        "through": "2.3.8"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                        },
+                        "chalk": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                            "requires": {
+                                "ansi-styles": "2.2.1",
+                                "escape-string-regexp": "1.0.5",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.1",
+                                "supports-color": "2.0.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            }
+                        }
+                    }
+                },
+                "invariant": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                    "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+                    "requires": {
+                        "loose-envify": "1.3.1"
+                    }
+                },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                    "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+                },
+                "is-alphabetical": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
+                    "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg="
+                },
+                "is-alphanumeric": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+                    "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ="
+                },
+                "is-alphanumerical": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
+                    "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
+                    "requires": {
+                        "is-alphabetical": "1.0.1",
+                        "is-decimal": "1.0.1"
+                    }
+                },
+                "is-arrayish": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                    "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+                },
+                "is-binary-path": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                    "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+                    "optional": true,
+                    "requires": {
+                        "binary-extensions": "1.11.0"
+                    }
+                },
+                "is-buffer": {
+                    "version": "1.1.6",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                    "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+                },
+                "is-builtin-module": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                    "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                    "requires": {
+                        "builtin-modules": "1.1.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+                    "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+                },
+                "is-date-object": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+                    "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+                },
+                "is-decimal": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
+                    "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI="
+                },
+                "is-directory": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+                    "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+                },
+                "is-dotfile": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+                    "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+                },
+                "is-equal-shallow": {
+                    "version": "0.1.3",
+                    "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                    "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+                    "requires": {
+                        "is-primitive": "2.0.0"
+                    }
+                },
+                "is-extendable": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                    "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+                },
+                "is-finite": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                    "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "is-hexadecimal": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
+                    "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk="
+                },
+                "is-number": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    }
+                },
+                "is-obj": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+                    "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+                },
+                "is-path-cwd": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+                    "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+                },
+                "is-path-in-cwd": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                    "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+                    "requires": {
+                        "is-path-inside": "1.0.1"
+                    }
+                },
+                "is-path-inside": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+                    "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+                    "requires": {
+                        "path-is-inside": "1.0.2"
+                    }
+                },
+                "is-plain-obj": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+                    "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+                },
+                "is-posix-bracket": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                    "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+                },
+                "is-primitive": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                    "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+                },
+                "is-promise": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+                    "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+                },
+                "is-regex": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+                    "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+                    "requires": {
+                        "has": "1.0.1"
+                    }
+                },
+                "is-regexp": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+                    "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+                },
+                "is-resolvable": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+                    "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+                },
+                "is-supported-regexp-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz",
+                    "integrity": "sha1-i1IMhfrnolM4LUsCZS4EVXbhO7g="
+                },
+                "is-symbol": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+                    "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                    "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+                },
+                "is-utf8": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+                    "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+                },
+                "is-whitespace-character": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz",
+                    "integrity": "sha1-muAXbzKCtlRXoZks2whPil+DPjs="
+                },
+                "is-windows": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+                    "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk="
+                },
+                "is-word-character": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.1.tgz",
+                    "integrity": "sha1-WgP6HqkazopusMfNdw64bWXIvvs="
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "isemail": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.0.tgz",
+                    "integrity": "sha512-Ke15MBbbhyIhZzWheiWuRlTO81tTH4RQvrbJFpVzJce8oyVrCVSDdrcw4TcyMsaS/fMGJSbU3lTsqCGDKwrzww==",
+                    "requires": {
+                        "punycode": "2.1.0"
+                    },
+                    "dependencies": {
+                        "punycode": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+                            "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+                        }
+                    }
+                },
+                "isexe": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                    "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+                },
+                "isobject": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                    "requires": {
+                        "isarray": "1.0.0"
+                    },
+                    "dependencies": {
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                        }
+                    }
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                    "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+                },
+                "istanbul-lib-coverage": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+                    "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
+                },
+                "istanbul-lib-instrument": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
+                    "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
+                    "requires": {
+                        "babel-generator": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0",
+                        "istanbul-lib-coverage": "1.1.1",
+                        "semver": "5.5.0"
+                    }
+                },
+                "joi": {
+                    "version": "12.0.0",
+                    "resolved": "https://registry.npmjs.org/joi/-/joi-12.0.0.tgz",
+                    "integrity": "sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==",
+                    "requires": {
+                        "hoek": "4.2.0",
+                        "isemail": "3.1.0",
+                        "topo": "2.0.2"
+                    }
+                },
+                "js-base64": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
+                    "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+                },
+                "js-yaml": {
+                    "version": "3.10.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+                    "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+                    "requires": {
+                        "argparse": "1.0.9",
+                        "esprima": "4.0.0"
+                    }
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                    "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+                    "optional": true
+                },
+                "jsesc": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+                    "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+                },
+                "jsmin": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/jsmin/-/jsmin-1.0.1.tgz",
+                    "integrity": "sha1-570NzWSWw79IYyNb9GGj2YqjuYw="
+                },
+                "json-parse-better-errors": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+                    "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                    "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+                },
+                "json-schema-traverse": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+                    "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+                },
+                "json-stable-stringify-without-jsonify": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+                    "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                    "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+                },
+                "json3": {
+                    "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+                    "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+                },
+                "json5": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+                },
+                "jsprim": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+                    "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.3.0",
+                        "json-schema": "0.2.3",
+                        "verror": "1.10.0"
+                    }
+                },
+                "just-extend": {
+                    "version": "1.1.27",
+                    "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+                    "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+                },
+                "jxLoader": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/jxLoader/-/jxLoader-0.1.1.tgz",
+                    "integrity": "sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=",
+                    "requires": {
+                        "js-yaml": "0.3.7",
+                        "moo-server": "1.3.0",
+                        "promised-io": "0.3.5",
+                        "walker": "1.0.7"
+                    },
+                    "dependencies": {
+                        "js-yaml": {
+                            "version": "0.3.7",
+                            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-0.3.7.tgz",
+                            "integrity": "sha1-1znY7oZGHlSzVNan19HyrZoWf2I="
+                        }
+                    }
+                },
+                "keypair": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz",
+                    "integrity": "sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs="
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                },
+                "known-css-properties": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.5.0.tgz",
+                    "integrity": "sha512-LOS0CoS8zcZnB1EjLw4LLqDXw8nvt3AGH5dXLQP3D9O1nLLA+9GC5GnPl5mmF+JiQAtSX4VyZC7KvEtcA4kUtA=="
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                    "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                    "requires": {
+                        "invert-kv": "1.0.0"
+                    }
+                },
+                "levn": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                    "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+                    "requires": {
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2"
+                    }
+                },
+                "load-json-file": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+                    "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "strip-bom": "3.0.0"
+                    },
+                    "dependencies": {
+                        "parse-json": {
+                            "version": "2.2.0",
+                            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                            "requires": {
+                                "error-ex": "1.3.1"
+                            }
+                        }
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "requires": {
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.4",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+                    "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+                },
+                "lodash._baseassign": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                    "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+                    "requires": {
+                        "lodash._basecopy": "3.0.1",
+                        "lodash.keys": "3.1.2"
+                    }
+                },
+                "lodash._basecopy": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                    "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+                },
+                "lodash._basecreate": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+                    "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
+                },
+                "lodash._getnative": {
+                    "version": "3.9.1",
+                    "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                    "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+                },
+                "lodash._isiterateecall": {
+                    "version": "3.0.9",
+                    "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                    "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+                },
+                "lodash.create": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+                    "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+                    "requires": {
+                        "lodash._baseassign": "3.2.0",
+                        "lodash._basecreate": "3.0.3",
+                        "lodash._isiterateecall": "3.0.9"
+                    }
+                },
+                "lodash.get": {
+                    "version": "4.4.2",
+                    "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+                    "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+                },
+                "lodash.isarguments": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                    "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+                },
+                "lodash.isarray": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                    "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+                },
+                "lodash.keys": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                    "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                    "requires": {
+                        "lodash._getnative": "3.9.1",
+                        "lodash.isarguments": "3.1.0",
+                        "lodash.isarray": "3.0.4"
+                    }
+                },
+                "log-symbols": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+                    "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+                    "requires": {
+                        "chalk": "2.3.0"
+                    }
+                },
+                "lolex": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
+                    "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw=="
+                },
+                "longest-streak": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
+                    "integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA=="
+                },
+                "loose-envify": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                    "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+                    "requires": {
+                        "js-tokens": "3.0.2"
+                    }
+                },
+                "loud-rejection": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+                    "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+                    "requires": {
+                        "currently-unhandled": "0.4.1",
+                        "signal-exit": "3.0.2"
+                    }
+                },
+                "lru-cache": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+                    "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+                    "requires": {
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
+                    }
+                },
+                "makeerror": {
+                    "version": "1.0.11",
+                    "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+                    "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+                    "requires": {
+                        "tmpl": "1.0.4"
+                    }
+                },
+                "map-obj": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+                    "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+                },
+                "markdown-escapes": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.1.tgz",
+                    "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg="
+                },
+                "markdown-table": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.1.tgz",
+                    "integrity": "sha1-Sz3ToTPRUYuO8NvHCb8qG0gkvIw="
+                },
+                "mathml-tag-names": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.0.1.tgz",
+                    "integrity": "sha1-jUEmgWi/htEQK5gQnijlMeejRXg="
+                },
+                "mdast-util-compact": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz",
+                    "integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
+                    "requires": {
+                        "unist-util-modify-children": "1.1.1",
+                        "unist-util-visit": "1.3.0"
+                    }
+                },
+                "mem": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+                    "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+                    "requires": {
+                        "mimic-fn": "1.1.0"
+                    }
+                },
+                "meow": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
+                    "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+                    "requires": {
+                        "camelcase-keys": "4.2.0",
+                        "decamelize-keys": "1.1.0",
+                        "loud-rejection": "1.6.0",
+                        "minimist": "1.2.0",
+                        "minimist-options": "3.0.2",
+                        "normalize-package-data": "2.4.0",
+                        "read-pkg-up": "3.0.0",
+                        "redent": "2.0.0",
+                        "trim-newlines": "2.0.0"
+                    },
+                    "dependencies": {
+                        "load-json-file": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+                            "requires": {
+                                "graceful-fs": "4.1.11",
+                                "parse-json": "4.0.0",
+                                "pify": "3.0.0",
+                                "strip-bom": "3.0.0"
+                            }
+                        },
+                        "parse-json": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                            "requires": {
+                                "error-ex": "1.3.1",
+                                "json-parse-better-errors": "1.0.1"
+                            }
+                        },
+                        "path-type": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                            "requires": {
+                                "pify": "3.0.0"
+                            }
+                        },
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+                        },
+                        "read-pkg": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+                            "requires": {
+                                "load-json-file": "4.0.0",
+                                "normalize-package-data": "2.4.0",
+                                "path-type": "3.0.0"
+                            }
+                        },
+                        "read-pkg-up": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                            "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+                            "requires": {
+                                "find-up": "2.1.0",
+                                "read-pkg": "3.0.0"
+                            }
+                        }
+                    }
+                },
+                "micromatch": {
+                    "version": "2.3.11",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                    "requires": {
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.4"
+                    }
+                },
+                "mime-db": {
+                    "version": "1.30.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+                    "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+                },
+                "mime-types": {
+                    "version": "2.1.17",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+                    "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+                    "requires": {
+                        "mime-db": "1.30.0"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+                    "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+                },
+                "minimist-options": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+                    "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+                    "requires": {
+                        "arrify": "1.0.1",
+                        "is-plain-obj": "1.1.0"
+                    }
+                },
+                "minipass": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.1.tgz",
+                    "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q==",
+                    "requires": {
+                        "yallist": "3.0.2"
+                    },
+                    "dependencies": {
+                        "yallist": {
+                            "version": "3.0.2",
+                            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+                            "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+                        }
+                    }
+                },
+                "minizlib": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+                    "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+                    "requires": {
+                        "minipass": "2.2.1"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "requires": {
+                        "minimist": "0.0.8"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "0.0.8",
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                        }
+                    }
+                },
+                "mocha": {
+                    "version": "3.5.3",
+                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+                    "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+                    "requires": {
+                        "browser-stdout": "1.3.0",
+                        "commander": "2.9.0",
+                        "debug": "2.6.8",
+                        "diff": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "glob": "7.1.1",
+                        "growl": "1.9.2",
+                        "he": "1.1.1",
+                        "json3": "3.3.2",
+                        "lodash.create": "3.1.1",
+                        "mkdirp": "0.5.1",
+                        "supports-color": "3.1.2"
+                    },
+                    "dependencies": {
+                        "commander": {
+                            "version": "2.9.0",
+                            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                            "requires": {
+                                "graceful-readlink": "1.0.1"
+                            }
+                        },
+                        "debug": {
+                            "version": "2.6.8",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                            "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "glob": {
+                            "version": "7.1.1",
+                            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                            "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+                            "requires": {
+                                "fs.realpath": "1.0.0",
+                                "inflight": "1.0.6",
+                                "inherits": "2.0.3",
+                                "minimatch": "3.0.4",
+                                "once": "1.4.0",
+                                "path-is-absolute": "1.0.1"
+                            }
+                        },
+                        "has-flag": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                            "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+                        },
+                        "supports-color": {
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+                            "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+                            "requires": {
+                                "has-flag": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "moo-server": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/moo-server/-/moo-server-1.3.0.tgz",
+                    "integrity": "sha1-XceVaVZaENbv7VQ5SR5p0jkuWPE="
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                },
+                "mute-stream": {
+                    "version": "0.0.7",
+                    "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+                    "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+                },
+                "nan": {
+                    "version": "2.8.0",
+                    "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+                    "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+                },
+                "native-promise-only": {
+                    "version": "0.8.1",
+                    "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+                    "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+                },
+                "natural-compare": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+                    "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+                },
+                "nise": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
+                    "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+                    "requires": {
+                        "formatio": "1.2.0",
+                        "just-extend": "1.1.27",
+                        "lolex": "1.6.0",
+                        "path-to-regexp": "1.7.0",
+                        "text-encoding": "0.6.4"
+                    },
+                    "dependencies": {
+                        "lolex": {
+                            "version": "1.6.0",
+                            "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+                            "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
+                        }
+                    }
+                },
+                "node-fetch": {
+                    "version": "1.6.3",
+                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+                    "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
+                    "requires": {
+                        "encoding": "0.1.12",
+                        "is-stream": "1.1.0"
+                    }
+                },
+                "node-forge": {
+                    "version": "0.7.1",
+                    "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
+                    "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA="
+                },
+                "nodemiral": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/nodemiral/-/nodemiral-1.1.1.tgz",
+                    "integrity": "sha1-FV8Mx+aPfhwXsfhQ1sVbt+F12OQ=",
+                    "requires": {
+                        "async": "0.9.0",
+                        "colors": "0.6.2",
+                        "debug": "0.7.4",
+                        "ejs": "0.8.8",
+                        "progress": "1.1.5",
+                        "ssh2": "0.4.6",
+                        "underscore": "1.8.3"
+                    },
+                    "dependencies": {
+                        "async": {
+                            "version": "0.9.0",
+                            "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+                            "integrity": "sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc="
+                        },
+                        "debug": {
+                            "version": "0.7.4",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                            "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+                        },
+                        "ssh2": {
+                            "version": "0.4.6",
+                            "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.4.6.tgz",
+                            "integrity": "sha1-0NLMNyqsYQv0plVF/gFiMx4mUJ0=",
+                            "requires": {
+                                "readable-stream": "1.0.34",
+                                "ssh2-streams": "0.0.23"
+                            }
+                        }
+                    }
+                },
+                "normalize-package-data": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+                    "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+                    "requires": {
+                        "hosted-git-info": "2.5.0",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.5.0",
+                        "validate-npm-package-license": "3.0.1"
+                    }
+                },
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "requires": {
+                        "remove-trailing-separator": "1.1.0"
+                    }
+                },
+                "normalize-range": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+                    "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+                },
+                "normalize-selector": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+                    "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM="
+                },
+                "npm-package-arg": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
+                    "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
+                    "requires": {
+                        "hosted-git-info": "2.5.0",
+                        "osenv": "0.1.4",
+                        "semver": "5.5.0",
+                        "validate-npm-package-name": "3.0.0"
+                    }
+                },
+                "npm-registry-client": {
+                    "version": "8.5.0",
+                    "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.5.0.tgz",
+                    "integrity": "sha512-Nkcw24bfECKFNt0FLDQ+PjVqSlKxMggcboXiUBIvjbCnA15xjRO4kCwRDluGNXZjHFLx/vPjN4+ESXyVjpXLbQ==",
+                    "requires": {
+                        "concat-stream": "1.6.0",
+                        "graceful-fs": "4.1.11",
+                        "normalize-package-data": "2.4.0",
+                        "npm-package-arg": "5.1.2",
+                        "npmlog": "4.1.2",
+                        "once": "1.4.0",
+                        "request": "2.83.0",
+                        "retry": "0.10.1",
+                        "semver": "5.5.0",
+                        "slide": "1.1.6",
+                        "ssri": "4.1.6"
+                    }
+                },
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                    "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+                    "requires": {
+                        "path-key": "2.0.1"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+                    "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                    }
+                },
+                "num2fraction": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+                    "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                },
+                "nyc": {
+                    "version": "11.4.1",
+                    "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
+                    "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+                    "requires": {
+                        "archy": "1.0.0",
+                        "arrify": "1.0.1",
+                        "caching-transform": "1.0.1",
+                        "convert-source-map": "1.5.1",
+                        "debug-log": "1.0.1",
+                        "default-require-extensions": "1.0.0",
+                        "find-cache-dir": "0.1.1",
+                        "find-up": "2.1.0",
+                        "foreground-child": "1.5.6",
+                        "glob": "7.1.2",
+                        "istanbul-lib-coverage": "1.1.1",
+                        "istanbul-lib-hook": "1.1.0",
+                        "istanbul-lib-instrument": "1.9.1",
+                        "istanbul-lib-report": "1.1.2",
+                        "istanbul-lib-source-maps": "1.2.2",
+                        "istanbul-reports": "1.1.3",
+                        "md5-hex": "1.3.0",
+                        "merge-source-map": "1.0.4",
+                        "micromatch": "2.3.11",
+                        "mkdirp": "0.5.1",
+                        "resolve-from": "2.0.0",
+                        "rimraf": "2.6.2",
+                        "signal-exit": "3.0.2",
+                        "spawn-wrap": "1.4.2",
+                        "test-exclude": "4.1.1",
+                        "yargs": "10.0.3",
+                        "yargs-parser": "8.0.0"
+                    },
+                    "dependencies": {
+                        "align-text": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                            "requires": {
+                                "kind-of": "3.2.2",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.6.1"
+                            }
+                        },
+                        "amdefine": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+                        },
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                        },
+                        "ansi-styles": {
+                            "version": "2.2.1",
+                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+                        },
+                        "append-transform": {
+                            "version": "0.4.0",
+                            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+                            "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+                            "requires": {
+                                "default-require-extensions": "1.0.0"
+                            }
+                        },
+                        "archy": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+                            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+                        },
+                        "arr-diff": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                            "requires": {
+                                "arr-flatten": "1.1.0"
+                            }
+                        },
+                        "arr-flatten": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+                            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+                        },
+                        "array-unique": {
+                            "version": "0.2.1",
+                            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+                        },
+                        "arrify": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+                        },
+                        "async": {
+                            "version": "1.5.2",
+                            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+                        },
+                        "babel-code-frame": {
+                            "version": "6.26.0",
+                            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+                            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+                            "requires": {
+                                "chalk": "1.1.3",
+                                "esutils": "2.0.2",
+                                "js-tokens": "3.0.2"
+                            }
+                        },
+                        "babel-generator": {
+                            "version": "6.26.0",
+                            "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+                            "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+                            "requires": {
+                                "babel-messages": "6.23.0",
+                                "babel-runtime": "6.26.0",
+                                "babel-types": "6.26.0",
+                                "detect-indent": "4.0.0",
+                                "jsesc": "1.3.0",
+                                "lodash": "4.17.4",
+                                "source-map": "0.5.7",
+                                "trim-right": "1.0.1"
+                            }
+                        },
+                        "babel-messages": {
+                            "version": "6.23.0",
+                            "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                            "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+                            "requires": {
+                                "babel-runtime": "6.26.0"
+                            }
+                        },
+                        "babel-runtime": {
+                            "version": "6.26.0",
+                            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+                            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+                            "requires": {
+                                "core-js": "2.5.3",
+                                "regenerator-runtime": "0.11.1"
+                            }
+                        },
+                        "babel-template": {
+                            "version": "6.26.0",
+                            "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+                            "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+                            "requires": {
+                                "babel-runtime": "6.26.0",
+                                "babel-traverse": "6.26.0",
+                                "babel-types": "6.26.0",
+                                "babylon": "6.18.0",
+                                "lodash": "4.17.4"
+                            }
+                        },
+                        "babel-traverse": {
+                            "version": "6.26.0",
+                            "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+                            "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+                            "requires": {
+                                "babel-code-frame": "6.26.0",
+                                "babel-messages": "6.23.0",
+                                "babel-runtime": "6.26.0",
+                                "babel-types": "6.26.0",
+                                "babylon": "6.18.0",
+                                "debug": "2.6.9",
+                                "globals": "9.18.0",
+                                "invariant": "2.2.2",
+                                "lodash": "4.17.4"
+                            }
+                        },
+                        "babel-types": {
+                            "version": "6.26.0",
+                            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+                            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+                            "requires": {
+                                "babel-runtime": "6.26.0",
+                                "esutils": "2.0.2",
+                                "lodash": "4.17.4",
+                                "to-fast-properties": "1.0.3"
+                            }
+                        },
+                        "babylon": {
+                            "version": "6.18.0",
+                            "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+                            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+                        },
+                        "balanced-match": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                        },
+                        "brace-expansion": {
+                            "version": "1.1.8",
+                            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                            "requires": {
+                                "balanced-match": "1.0.0",
+                                "concat-map": "0.0.1"
+                            }
+                        },
+                        "braces": {
+                            "version": "1.8.5",
+                            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                            "requires": {
+                                "expand-range": "1.8.2",
+                                "preserve": "0.2.0",
+                                "repeat-element": "1.1.2"
+                            }
+                        },
+                        "builtin-modules": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+                        },
+                        "caching-transform": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+                            "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+                            "requires": {
+                                "md5-hex": "1.3.0",
+                                "mkdirp": "0.5.1",
+                                "write-file-atomic": "1.3.4"
+                            }
+                        },
+                        "camelcase": {
+                            "version": "1.2.1",
+                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                            "optional": true
+                        },
+                        "center-align": {
+                            "version": "0.1.3",
+                            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                            "optional": true,
+                            "requires": {
+                                "align-text": "0.1.4",
+                                "lazy-cache": "1.0.4"
+                            }
+                        },
+                        "chalk": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                            "requires": {
+                                "ansi-styles": "2.2.1",
+                                "escape-string-regexp": "1.0.5",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.1",
+                                "supports-color": "2.0.0"
+                            }
+                        },
+                        "cliui": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                            "optional": true,
+                            "requires": {
+                                "center-align": "0.1.3",
+                                "right-align": "0.1.3",
+                                "wordwrap": "0.0.2"
+                            },
+                            "dependencies": {
+                                "wordwrap": {
+                                    "version": "0.0.2",
+                                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                                    "optional": true
+                                }
+                            }
+                        },
+                        "code-point-at": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+                        },
+                        "commondir": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+                            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+                        },
+                        "concat-map": {
+                            "version": "0.0.1",
+                            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                        },
+                        "convert-source-map": {
+                            "version": "1.5.1",
+                            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+                            "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+                        },
+                        "core-js": {
+                            "version": "2.5.3",
+                            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+                            "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+                        },
+                        "cross-spawn": {
+                            "version": "4.0.2",
+                            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+                            "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+                            "requires": {
+                                "lru-cache": "4.1.1",
+                                "which": "1.3.0"
+                            }
+                        },
+                        "debug": {
+                            "version": "2.6.9",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "debug-log": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+                            "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8="
+                        },
+                        "decamelize": {
+                            "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+                        },
+                        "default-require-extensions": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+                            "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+                            "requires": {
+                                "strip-bom": "2.0.0"
+                            }
+                        },
+                        "detect-indent": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+                            "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+                            "requires": {
+                                "repeating": "2.0.1"
+                            }
+                        },
+                        "error-ex": {
+                            "version": "1.3.1",
+                            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+                            "requires": {
+                                "is-arrayish": "0.2.1"
+                            }
+                        },
+                        "escape-string-regexp": {
+                            "version": "1.0.5",
+                            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+                        },
+                        "esutils": {
+                            "version": "2.0.2",
+                            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                        },
+                        "execa": {
+                            "version": "0.7.0",
+                            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+                            "requires": {
+                                "cross-spawn": "5.1.0",
+                                "get-stream": "3.0.0",
+                                "is-stream": "1.1.0",
+                                "npm-run-path": "2.0.2",
+                                "p-finally": "1.0.0",
+                                "signal-exit": "3.0.2",
+                                "strip-eof": "1.0.0"
+                            },
+                            "dependencies": {
+                                "cross-spawn": {
+                                    "version": "5.1.0",
+                                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                                    "requires": {
+                                        "lru-cache": "4.1.1",
+                                        "shebang-command": "1.2.0",
+                                        "which": "1.3.0"
+                                    }
+                                }
+                            }
+                        },
+                        "expand-brackets": {
+                            "version": "0.1.5",
+                            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                            "requires": {
+                                "is-posix-bracket": "0.1.1"
+                            }
+                        },
+                        "expand-range": {
+                            "version": "1.8.2",
+                            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+                            "requires": {
+                                "fill-range": "2.2.3"
+                            }
+                        },
+                        "extglob": {
+                            "version": "0.3.2",
+                            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                            "requires": {
+                                "is-extglob": "1.0.0"
+                            }
+                        },
+                        "filename-regex": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+                            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+                        },
+                        "fill-range": {
+                            "version": "2.2.3",
+                            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                            "requires": {
+                                "is-number": "2.1.0",
+                                "isobject": "2.1.0",
+                                "randomatic": "1.1.7",
+                                "repeat-element": "1.1.2",
+                                "repeat-string": "1.6.1"
+                            }
+                        },
+                        "find-cache-dir": {
+                            "version": "0.1.1",
+                            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+                            "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+                            "requires": {
+                                "commondir": "1.0.1",
+                                "mkdirp": "0.5.1",
+                                "pkg-dir": "1.0.0"
+                            }
+                        },
+                        "find-up": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                            "requires": {
+                                "locate-path": "2.0.0"
+                            }
+                        },
+                        "for-in": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+                            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+                        },
+                        "for-own": {
+                            "version": "0.1.5",
+                            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+                            "requires": {
+                                "for-in": "1.0.2"
+                            }
+                        },
+                        "foreground-child": {
+                            "version": "1.5.6",
+                            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+                            "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+                            "requires": {
+                                "cross-spawn": "4.0.2",
+                                "signal-exit": "3.0.2"
+                            }
+                        },
+                        "fs.realpath": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+                        },
+                        "get-caller-file": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+                            "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+                        },
+                        "get-stream": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+                        },
+                        "glob": {
+                            "version": "7.1.2",
+                            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                            "requires": {
+                                "fs.realpath": "1.0.0",
+                                "inflight": "1.0.6",
+                                "inherits": "2.0.3",
+                                "minimatch": "3.0.4",
+                                "once": "1.4.0",
+                                "path-is-absolute": "1.0.1"
+                            }
+                        },
+                        "glob-base": {
+                            "version": "0.3.0",
+                            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+                            "requires": {
+                                "glob-parent": "2.0.0",
+                                "is-glob": "2.0.1"
+                            }
+                        },
+                        "glob-parent": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                            "requires": {
+                                "is-glob": "2.0.1"
+                            }
+                        },
+                        "globals": {
+                            "version": "9.18.0",
+                            "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                            "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+                        },
+                        "graceful-fs": {
+                            "version": "4.1.11",
+                            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+                        },
+                        "handlebars": {
+                            "version": "4.0.11",
+                            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+                            "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+                            "requires": {
+                                "async": "1.5.2",
+                                "optimist": "0.6.1",
+                                "source-map": "0.4.4",
+                                "uglify-js": "2.8.29"
+                            },
+                            "dependencies": {
+                                "source-map": {
+                                    "version": "0.4.4",
+                                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                                    "requires": {
+                                        "amdefine": "1.0.1"
+                                    }
+                                }
+                            }
+                        },
+                        "has-ansi": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            }
+                        },
+                        "has-flag": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                            "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+                        },
+                        "hosted-git-info": {
+                            "version": "2.5.0",
+                            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+                            "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+                        },
+                        "imurmurhash": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+                        },
+                        "inflight": {
+                            "version": "1.0.6",
+                            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                            "requires": {
+                                "once": "1.4.0",
+                                "wrappy": "1.0.2"
+                            }
+                        },
+                        "inherits": {
+                            "version": "2.0.3",
+                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                        },
+                        "invariant": {
+                            "version": "2.2.2",
+                            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                            "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+                            "requires": {
+                                "loose-envify": "1.3.1"
+                            }
+                        },
+                        "invert-kv": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+                        },
+                        "is-arrayish": {
+                            "version": "0.2.1",
+                            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+                        },
+                        "is-buffer": {
+                            "version": "1.1.6",
+                            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+                        },
+                        "is-builtin-module": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                            "requires": {
+                                "builtin-modules": "1.1.1"
+                            }
+                        },
+                        "is-dotfile": {
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+                            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+                        },
+                        "is-equal-shallow": {
+                            "version": "0.1.3",
+                            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+                            "requires": {
+                                "is-primitive": "2.0.0"
+                            }
+                        },
+                        "is-extendable": {
+                            "version": "0.1.1",
+                            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+                        },
+                        "is-extglob": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+                        },
+                        "is-finite": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+                            "requires": {
+                                "number-is-nan": "1.0.1"
+                            }
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                            "requires": {
+                                "number-is-nan": "1.0.1"
+                            }
+                        },
+                        "is-glob": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                            "requires": {
+                                "is-extglob": "1.0.0"
+                            }
+                        },
+                        "is-number": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                            "requires": {
+                                "kind-of": "3.2.2"
+                            }
+                        },
+                        "is-posix-bracket": {
+                            "version": "0.1.1",
+                            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+                        },
+                        "is-primitive": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+                        },
+                        "is-stream": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+                        },
+                        "is-utf8": {
+                            "version": "0.2.1",
+                            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+                            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+                        },
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                        },
+                        "isexe": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+                        },
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        },
+                        "istanbul-lib-coverage": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+                            "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
+                        },
+                        "istanbul-lib-hook": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+                            "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+                            "requires": {
+                                "append-transform": "0.4.0"
+                            }
+                        },
+                        "istanbul-lib-instrument": {
+                            "version": "1.9.1",
+                            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
+                            "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
+                            "requires": {
+                                "babel-generator": "6.26.0",
+                                "babel-template": "6.26.0",
+                                "babel-traverse": "6.26.0",
+                                "babel-types": "6.26.0",
+                                "babylon": "6.18.0",
+                                "istanbul-lib-coverage": "1.1.1",
+                                "semver": "5.4.1"
+                            }
+                        },
+                        "istanbul-lib-report": {
+                            "version": "1.1.2",
+                            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
+                            "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
+                            "requires": {
+                                "istanbul-lib-coverage": "1.1.1",
+                                "mkdirp": "0.5.1",
+                                "path-parse": "1.0.5",
+                                "supports-color": "3.2.3"
+                            },
+                            "dependencies": {
+                                "supports-color": {
+                                    "version": "3.2.3",
+                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                                    "requires": {
+                                        "has-flag": "1.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "istanbul-lib-source-maps": {
+                            "version": "1.2.2",
+                            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
+                            "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
+                            "requires": {
+                                "debug": "3.1.0",
+                                "istanbul-lib-coverage": "1.1.1",
+                                "mkdirp": "0.5.1",
+                                "rimraf": "2.6.2",
+                                "source-map": "0.5.7"
+                            },
+                            "dependencies": {
+                                "debug": {
+                                    "version": "3.1.0",
+                                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                                    "requires": {
+                                        "ms": "2.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "istanbul-reports": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
+                            "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
+                            "requires": {
+                                "handlebars": "4.0.11"
+                            }
+                        },
+                        "js-tokens": {
+                            "version": "3.0.2",
+                            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+                        },
+                        "jsesc": {
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+                            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+                        },
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        },
+                        "lazy-cache": {
+                            "version": "1.0.4",
+                            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                            "optional": true
+                        },
+                        "lcid": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                            "requires": {
+                                "invert-kv": "1.0.0"
+                            }
+                        },
+                        "load-json-file": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                            "requires": {
+                                "graceful-fs": "4.1.11",
+                                "parse-json": "2.2.0",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1",
+                                "strip-bom": "2.0.0"
+                            }
+                        },
+                        "locate-path": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                            "requires": {
+                                "p-locate": "2.0.0",
+                                "path-exists": "3.0.0"
+                            },
+                            "dependencies": {
+                                "path-exists": {
+                                    "version": "3.0.0",
+                                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                                }
+                            }
+                        },
+                        "lodash": {
+                            "version": "4.17.4",
+                            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+                            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+                        },
+                        "longest": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+                        },
+                        "loose-envify": {
+                            "version": "1.3.1",
+                            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                            "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+                            "requires": {
+                                "js-tokens": "3.0.2"
+                            }
+                        },
+                        "lru-cache": {
+                            "version": "4.1.1",
+                            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+                            "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+                            "requires": {
+                                "pseudomap": "1.0.2",
+                                "yallist": "2.1.2"
+                            }
+                        },
+                        "md5-hex": {
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+                            "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+                            "requires": {
+                                "md5-o-matic": "0.1.1"
+                            }
+                        },
+                        "md5-o-matic": {
+                            "version": "0.1.1",
+                            "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+                            "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
+                        },
+                        "mem": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+                            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+                            "requires": {
+                                "mimic-fn": "1.1.0"
+                            }
+                        },
+                        "merge-source-map": {
+                            "version": "1.0.4",
+                            "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+                            "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+                            "requires": {
+                                "source-map": "0.5.7"
+                            }
+                        },
+                        "micromatch": {
+                            "version": "2.3.11",
+                            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                            "requires": {
+                                "arr-diff": "2.0.0",
+                                "array-unique": "0.2.1",
+                                "braces": "1.8.5",
+                                "expand-brackets": "0.1.5",
+                                "extglob": "0.3.2",
+                                "filename-regex": "2.0.1",
+                                "is-extglob": "1.0.0",
+                                "is-glob": "2.0.1",
+                                "kind-of": "3.2.2",
+                                "normalize-path": "2.1.1",
+                                "object.omit": "2.0.1",
+                                "parse-glob": "3.0.4",
+                                "regex-cache": "0.4.4"
+                            }
+                        },
+                        "mimic-fn": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+                            "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+                        },
+                        "minimatch": {
+                            "version": "3.0.4",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                            "requires": {
+                                "brace-expansion": "1.1.8"
+                            }
+                        },
+                        "minimist": {
+                            "version": "0.0.8",
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                        },
+                        "mkdirp": {
+                            "version": "0.5.1",
+                            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                            "requires": {
+                                "minimist": "0.0.8"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                        },
+                        "normalize-package-data": {
+                            "version": "2.4.0",
+                            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+                            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+                            "requires": {
+                                "hosted-git-info": "2.5.0",
+                                "is-builtin-module": "1.0.0",
+                                "semver": "5.4.1",
+                                "validate-npm-package-license": "3.0.1"
+                            }
+                        },
+                        "normalize-path": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                            "requires": {
+                                "remove-trailing-separator": "1.1.0"
+                            }
+                        },
+                        "npm-run-path": {
+                            "version": "2.0.2",
+                            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+                            "requires": {
+                                "path-key": "2.0.1"
+                            }
+                        },
+                        "number-is-nan": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                        },
+                        "object-assign": {
+                            "version": "4.1.1",
+                            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+                        },
+                        "object.omit": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+                            "requires": {
+                                "for-own": "0.1.5",
+                                "is-extendable": "0.1.1"
+                            }
+                        },
+                        "once": {
+                            "version": "1.4.0",
+                            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                            "requires": {
+                                "wrappy": "1.0.2"
+                            }
+                        },
+                        "optimist": {
+                            "version": "0.6.1",
+                            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+                            "requires": {
+                                "minimist": "0.0.8",
+                                "wordwrap": "0.0.3"
+                            }
+                        },
+                        "os-homedir": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+                        },
+                        "os-locale": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+                            "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+                            "requires": {
+                                "execa": "0.7.0",
+                                "lcid": "1.0.0",
+                                "mem": "1.1.0"
+                            }
+                        },
+                        "p-finally": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+                        },
+                        "p-limit": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+                            "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+                        },
+                        "p-locate": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                            "requires": {
+                                "p-limit": "1.1.0"
+                            }
+                        },
+                        "parse-glob": {
+                            "version": "3.0.4",
+                            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+                            "requires": {
+                                "glob-base": "0.3.0",
+                                "is-dotfile": "1.0.3",
+                                "is-extglob": "1.0.0",
+                                "is-glob": "2.0.1"
+                            }
+                        },
+                        "parse-json": {
+                            "version": "2.2.0",
+                            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                            "requires": {
+                                "error-ex": "1.3.1"
+                            }
+                        },
+                        "path-exists": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                            "requires": {
+                                "pinkie-promise": "2.0.1"
+                            }
+                        },
+                        "path-is-absolute": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+                        },
+                        "path-key": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+                        },
+                        "path-parse": {
+                            "version": "1.0.5",
+                            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+                            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+                        },
+                        "path-type": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                            "requires": {
+                                "graceful-fs": "4.1.11",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1"
+                            }
+                        },
+                        "pify": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                        },
+                        "pinkie": {
+                            "version": "2.0.4",
+                            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+                        },
+                        "pinkie-promise": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                            "requires": {
+                                "pinkie": "2.0.4"
+                            }
+                        },
+                        "pkg-dir": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+                            "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+                            "requires": {
+                                "find-up": "1.1.2"
+                            },
+                            "dependencies": {
+                                "find-up": {
+                                    "version": "1.1.2",
+                                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                                    "requires": {
+                                        "path-exists": "2.1.0",
+                                        "pinkie-promise": "2.0.1"
+                                    }
+                                }
+                            }
+                        },
+                        "preserve": {
+                            "version": "0.2.0",
+                            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+                        },
+                        "pseudomap": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+                        },
+                        "randomatic": {
+                            "version": "1.1.7",
+                            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+                            "requires": {
+                                "is-number": "3.0.0",
+                                "kind-of": "4.0.0"
+                            },
+                            "dependencies": {
+                                "is-number": {
+                                    "version": "3.0.0",
+                                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                                    "requires": {
+                                        "kind-of": "3.2.2"
+                                    },
+                                    "dependencies": {
+                                        "kind-of": {
+                                            "version": "3.2.2",
+                                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                            "requires": {
+                                                "is-buffer": "1.1.6"
+                                            }
+                                        }
+                                    }
+                                },
+                                "kind-of": {
+                                    "version": "4.0.0",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                                    "requires": {
+                                        "is-buffer": "1.1.6"
+                                    }
+                                }
+                            }
+                        },
+                        "read-pkg": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                            "requires": {
+                                "load-json-file": "1.1.0",
+                                "normalize-package-data": "2.4.0",
+                                "path-type": "1.1.0"
+                            }
+                        },
+                        "read-pkg-up": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                            "requires": {
+                                "find-up": "1.1.2",
+                                "read-pkg": "1.1.0"
+                            },
+                            "dependencies": {
+                                "find-up": {
+                                    "version": "1.1.2",
+                                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                                    "requires": {
+                                        "path-exists": "2.1.0",
+                                        "pinkie-promise": "2.0.1"
+                                    }
+                                }
+                            }
+                        },
+                        "regenerator-runtime": {
+                            "version": "0.11.1",
+                            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+                            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+                        },
+                        "regex-cache": {
+                            "version": "0.4.4",
+                            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+                            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+                            "requires": {
+                                "is-equal-shallow": "0.1.3"
+                            }
+                        },
+                        "remove-trailing-separator": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+                            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+                        },
+                        "repeat-element": {
+                            "version": "1.1.2",
+                            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+                        },
+                        "repeat-string": {
+                            "version": "1.6.1",
+                            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+                        },
+                        "repeating": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+                            "requires": {
+                                "is-finite": "1.0.2"
+                            }
+                        },
+                        "require-directory": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+                            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+                        },
+                        "require-main-filename": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+                        },
+                        "resolve-from": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+                            "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+                        },
+                        "right-align": {
+                            "version": "0.1.3",
+                            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                            "optional": true,
+                            "requires": {
+                                "align-text": "0.1.4"
+                            }
+                        },
+                        "rimraf": {
+                            "version": "2.6.2",
+                            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+                            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+                            "requires": {
+                                "glob": "7.1.2"
+                            }
+                        },
+                        "semver": {
+                            "version": "5.4.1",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+                            "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+                        },
+                        "set-blocking": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+                        },
+                        "shebang-command": {
+                            "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+                            "requires": {
+                                "shebang-regex": "1.0.0"
+                            }
+                        },
+                        "shebang-regex": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+                        },
+                        "signal-exit": {
+                            "version": "3.0.2",
+                            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+                        },
+                        "slide": {
+                            "version": "1.1.6",
+                            "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+                            "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+                        },
+                        "source-map": {
+                            "version": "0.5.7",
+                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+                        },
+                        "spawn-wrap": {
+                            "version": "1.4.2",
+                            "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+                            "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+                            "requires": {
+                                "foreground-child": "1.5.6",
+                                "mkdirp": "0.5.1",
+                                "os-homedir": "1.0.2",
+                                "rimraf": "2.6.2",
+                                "signal-exit": "3.0.2",
+                                "which": "1.3.0"
+                            }
+                        },
+                        "spdx-correct": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                            "requires": {
+                                "spdx-license-ids": "1.2.2"
+                            }
+                        },
+                        "spdx-expression-parse": {
+                            "version": "1.0.4",
+                            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+                            "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+                        },
+                        "spdx-license-ids": {
+                            "version": "1.2.2",
+                            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                            "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+                        },
+                        "string-width": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                            "requires": {
+                                "is-fullwidth-code-point": "2.0.0",
+                                "strip-ansi": "4.0.0"
+                            },
+                            "dependencies": {
+                                "ansi-regex": {
+                                    "version": "3.0.0",
+                                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                                },
+                                "is-fullwidth-code-point": {
+                                    "version": "2.0.0",
+                                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+                                },
+                                "strip-ansi": {
+                                    "version": "4.0.0",
+                                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                                    "requires": {
+                                        "ansi-regex": "3.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            }
+                        },
+                        "strip-bom": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                            "requires": {
+                                "is-utf8": "0.2.1"
+                            }
+                        },
+                        "strip-eof": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+                        },
+                        "supports-color": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                        },
+                        "test-exclude": {
+                            "version": "4.1.1",
+                            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+                            "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+                            "requires": {
+                                "arrify": "1.0.1",
+                                "micromatch": "2.3.11",
+                                "object-assign": "4.1.1",
+                                "read-pkg-up": "1.0.1",
+                                "require-main-filename": "1.0.1"
+                            }
+                        },
+                        "to-fast-properties": {
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+                        },
+                        "trim-right": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+                            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+                        },
+                        "uglify-js": {
+                            "version": "2.8.29",
+                            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+                            "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+                            "optional": true,
+                            "requires": {
+                                "source-map": "0.5.7",
+                                "uglify-to-browserify": "1.0.2",
+                                "yargs": "3.10.0"
+                            },
+                            "dependencies": {
+                                "yargs": {
+                                    "version": "3.10.0",
+                                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                                    "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                                    "optional": true,
+                                    "requires": {
+                                        "camelcase": "1.2.1",
+                                        "cliui": "2.1.0",
+                                        "decamelize": "1.2.0",
+                                        "window-size": "0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "uglify-to-browserify": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+                            "optional": true
+                        },
+                        "validate-npm-package-license": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                            "requires": {
+                                "spdx-correct": "1.0.2",
+                                "spdx-expression-parse": "1.0.4"
+                            }
+                        },
+                        "which": {
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+                            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+                            "requires": {
+                                "isexe": "2.0.0"
+                            }
+                        },
+                        "which-module": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+                        },
+                        "window-size": {
+                            "version": "0.1.0",
+                            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                            "optional": true
+                        },
+                        "wordwrap": {
+                            "version": "0.0.3",
+                            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+                        },
+                        "wrap-ansi": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+                            "requires": {
+                                "string-width": "1.0.2",
+                                "strip-ansi": "3.0.1"
+                            },
+                            "dependencies": {
+                                "string-width": {
+                                    "version": "1.0.2",
+                                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                                    "requires": {
+                                        "code-point-at": "1.1.0",
+                                        "is-fullwidth-code-point": "1.0.0",
+                                        "strip-ansi": "3.0.1"
+                                    }
+                                }
+                            }
+                        },
+                        "wrappy": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                        },
+                        "write-file-atomic": {
+                            "version": "1.3.4",
+                            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+                            "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+                            "requires": {
+                                "graceful-fs": "4.1.11",
+                                "imurmurhash": "0.1.4",
+                                "slide": "1.1.6"
+                            }
+                        },
+                        "y18n": {
+                            "version": "3.2.1",
+                            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+                        },
+                        "yallist": {
+                            "version": "2.1.2",
+                            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+                        },
+                        "yargs": {
+                            "version": "10.0.3",
+                            "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+                            "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+                            "requires": {
+                                "cliui": "3.2.0",
+                                "decamelize": "1.2.0",
+                                "find-up": "2.1.0",
+                                "get-caller-file": "1.0.2",
+                                "os-locale": "2.1.0",
+                                "require-directory": "2.1.1",
+                                "require-main-filename": "1.0.1",
+                                "set-blocking": "2.0.0",
+                                "string-width": "2.1.1",
+                                "which-module": "2.0.0",
+                                "y18n": "3.2.1",
+                                "yargs-parser": "8.0.0"
+                            },
+                            "dependencies": {
+                                "cliui": {
+                                    "version": "3.2.0",
+                                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                                    "requires": {
+                                        "string-width": "1.0.2",
+                                        "strip-ansi": "3.0.1",
+                                        "wrap-ansi": "2.1.0"
+                                    },
+                                    "dependencies": {
+                                        "string-width": {
+                                            "version": "1.0.2",
+                                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                                            "requires": {
+                                                "code-point-at": "1.1.0",
+                                                "is-fullwidth-code-point": "1.0.0",
+                                                "strip-ansi": "3.0.1"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "yargs-parser": {
+                            "version": "8.0.0",
+                            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+                            "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+                            "requires": {
+                                "camelcase": "4.1.0"
+                            },
+                            "dependencies": {
+                                "camelcase": {
+                                    "version": "4.1.0",
+                                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+                                }
+                            }
+                        }
+                    }
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                    "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+                },
+                "object-keys": {
+                    "version": "1.0.11",
+                    "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+                    "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+                },
+                "object.omit": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                    "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+                    "requires": {
+                        "for-own": "0.1.5",
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "onetime": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+                    "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+                    "requires": {
+                        "mimic-fn": "1.1.0"
+                    }
+                },
+                "opencollective": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
+                    "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
+                    "requires": {
+                        "babel-polyfill": "6.23.0",
+                        "chalk": "1.1.3",
+                        "inquirer": "3.0.6",
+                        "minimist": "1.2.0",
+                        "node-fetch": "1.6.3",
+                        "opn": "4.0.2"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                        },
+                        "babel-polyfill": {
+                            "version": "6.23.0",
+                            "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+                            "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+                            "requires": {
+                                "babel-runtime": "6.26.0",
+                                "core-js": "2.5.3",
+                                "regenerator-runtime": "0.10.5"
+                            }
+                        },
+                        "chalk": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                            "requires": {
+                                "ansi-styles": "2.2.1",
+                                "escape-string-regexp": "1.0.5",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.1",
+                                "supports-color": "2.0.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            }
+                        }
+                    }
+                },
+                "opn": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+                    "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+                    "requires": {
+                        "object-assign": "4.1.1",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "optionator": {
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+                    "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+                    "requires": {
+                        "deep-is": "0.1.3",
+                        "fast-levenshtein": "2.0.6",
+                        "levn": "0.3.0",
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2",
+                        "wordwrap": "1.0.0"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+                    "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+                    "requires": {
+                        "execa": "0.7.0",
+                        "lcid": "1.0.0",
+                        "mem": "1.1.0"
+                    }
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                    "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+                },
+                "osenv": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+                    "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "output-file-sync": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+                    "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "mkdirp": "0.5.1",
+                        "object-assign": "4.1.1"
+                    }
+                },
+                "p-finally": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                    "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+                },
+                "p-limit": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+                    "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+                    "requires": {
+                        "p-try": "1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "requires": {
+                        "p-limit": "1.2.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+                },
+                "parse-entities": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz",
+                    "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
+                    "requires": {
+                        "character-entities": "1.2.1",
+                        "character-entities-legacy": "1.1.1",
+                        "character-reference-invalid": "1.1.1",
+                        "is-alphanumerical": "1.0.1",
+                        "is-decimal": "1.0.1",
+                        "is-hexadecimal": "1.0.1"
+                    }
+                },
+                "parse-glob": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                    "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+                    "requires": {
+                        "glob-base": "0.3.0",
+                        "is-dotfile": "1.0.3",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1"
+                    }
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                    "requires": {
+                        "error-ex": "1.3.1",
+                        "json-parse-better-errors": "1.0.1"
+                    }
+                },
+                "parse-passwd": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+                    "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+                },
+                "path-is-inside": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+                    "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+                },
+                "path-to-regexp": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+                    "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+                    "requires": {
+                        "isarray": "0.0.1"
+                    }
+                },
+                "path-type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+                    "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+                    "requires": {
+                        "pify": "2.3.0"
+                    }
+                },
+                "pathval": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+                    "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+                },
+                "performance-now": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+                    "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                },
+                "pinkie": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                    "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+                },
+                "pinkie-promise": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                    "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                    "requires": {
+                        "pinkie": "2.0.4"
+                    }
+                },
+                "pluralize": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+                    "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+                },
+                "postcss": {
+                    "version": "6.0.16",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+                    "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+                    "requires": {
+                        "chalk": "2.3.0",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.1.0"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                        },
+                        "supports-color": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+                            "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+                            "requires": {
+                                "has-flag": "2.0.0"
+                            }
+                        }
+                    }
+                },
+                "postcss-html": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.12.0.tgz",
+                    "integrity": "sha512-KxKUpj7AY7nlCbLcTOYxdfJnGE7QFAfU2n95ADj1Q90RM/pOLdz8k3n4avOyRFs7MDQHcRzJQWM1dehCwJxisQ==",
+                    "requires": {
+                        "htmlparser2": "3.9.2",
+                        "remark": "8.0.0",
+                        "unist-util-find-all-after": "1.0.1"
+                    }
+                },
+                "postcss-less": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.3.tgz",
+                    "integrity": "sha512-WS0wsQxRm+kmN8wEYAGZ3t4lnoNfoyx9EJZrhiPR1K0lMHR0UNWnz52Ya5QRXChHtY75Ef+kDc05FpnBujebgw==",
+                    "requires": {
+                        "postcss": "5.2.18"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                        },
+                        "chalk": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                            "requires": {
+                                "ansi-styles": "2.2.1",
+                                "escape-string-regexp": "1.0.5",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.1",
+                                "supports-color": "2.0.0"
+                            },
+                            "dependencies": {
+                                "supports-color": {
+                                    "version": "2.0.0",
+                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                }
+                            }
+                        },
+                        "has-flag": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                            "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+                        },
+                        "postcss": {
+                            "version": "5.2.18",
+                            "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+                            "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+                            "requires": {
+                                "chalk": "1.1.3",
+                                "js-base64": "2.4.3",
+                                "source-map": "0.5.7",
+                                "supports-color": "3.2.3"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            }
+                        },
+                        "supports-color": {
+                            "version": "3.2.3",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                            "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                            "requires": {
+                                "has-flag": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "postcss-media-query-parser": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+                    "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
+                },
+                "postcss-reporter": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-5.0.0.tgz",
+                    "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
+                    "requires": {
+                        "chalk": "2.3.0",
+                        "lodash": "4.17.4",
+                        "log-symbols": "2.2.0",
+                        "postcss": "6.0.16"
+                    }
+                },
+                "postcss-resolve-nested-selector": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+                    "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4="
+                },
+                "postcss-safe-parser": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-3.0.1.tgz",
+                    "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
+                    "requires": {
+                        "postcss": "6.0.16"
+                    }
+                },
+                "postcss-sass": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.2.0.tgz",
+                    "integrity": "sha512-cUmYzkP747fPCQE6d+CH2l1L4VSyIlAzZsok3HPjb5Gzsq3jE+VjpAdGlPsnQ310WKWI42sw+ar0UNN59/f3hg==",
+                    "requires": {
+                        "gonzales-pe": "4.2.3",
+                        "postcss": "6.0.16"
+                    }
+                },
+                "postcss-scss": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.3.tgz",
+                    "integrity": "sha512-N2ZPDOV5PGEGVwdiB7b1QppxKkmkHodNWkemja7PV+/mHqbUlA6ZcYRreden5Ag5nwBBX8/aRE7lfg1xjdszyg==",
+                    "requires": {
+                        "postcss": "6.0.16"
+                    }
+                },
+                "postcss-selector-parser": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "requires": {
+                        "dot-prop": "4.2.0",
+                        "indexes-of": "1.0.1",
+                        "uniq": "1.0.1"
+                    }
+                },
+                "postcss-value-parser": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+                    "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+                },
+                "prelude-ls": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                    "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+                },
+                "preserve": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                    "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+                },
+                "private": {
+                    "version": "0.1.8",
+                    "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+                    "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+                },
+                "progress": {
+                    "version": "1.1.5",
+                    "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.5.tgz",
+                    "integrity": "sha1-CVSyWqNhMueyZMZ8OI8HORmzh9A="
+                },
+                "promised-io": {
+                    "version": "0.3.5",
+                    "resolved": "https://registry.npmjs.org/promised-io/-/promised-io-0.3.5.tgz",
+                    "integrity": "sha1-StIXuzZYvKrplGsXqGaOzYUeE1Y="
+                },
+                "pseudomap": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                    "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+                },
+                "qs": {
+                    "version": "6.5.1",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+                },
+                "quick-lru": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+                    "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
+                },
+                "random-seed": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/random-seed/-/random-seed-0.3.0.tgz",
+                    "integrity": "sha1-2UXy4fOPSejViRNDG4v2u5N1Vs0=",
+                    "requires": {
+                        "json-stringify-safe": "5.0.1"
+                    }
+                },
+                "randomatic": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                    "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+                    "requires": {
+                        "is-number": "3.0.0",
+                        "kind-of": "4.0.0"
+                    },
+                    "dependencies": {
+                        "is-number": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                            "requires": {
+                                "kind-of": "3.2.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "requires": {
+                                        "is-buffer": "1.1.6"
+                                    }
+                                }
+                            }
+                        },
+                        "kind-of": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                            "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "read-pkg": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+                    "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+                    "requires": {
+                        "load-json-file": "2.0.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "2.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+                    "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+                    "requires": {
+                        "find-up": "2.1.0",
+                        "read-pkg": "2.0.0"
+                    }
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
+                },
+                "readdirp": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+                    "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+                    "optional": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "minimatch": "3.0.4",
+                        "readable-stream": "2.3.3",
+                        "set-immediate-shim": "1.0.1"
+                    },
+                    "dependencies": {
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                            "optional": true
+                        },
+                        "readable-stream": {
+                            "version": "2.3.3",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                            "optional": true,
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "1.0.7",
+                                "safe-buffer": "5.1.1",
+                                "string_decoder": "1.0.3",
+                                "util-deprecate": "1.0.2"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                            "optional": true,
+                            "requires": {
+                                "safe-buffer": "5.1.1"
+                            }
+                        }
+                    }
+                },
+                "redent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+                    "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+                    "requires": {
+                        "indent-string": "3.2.0",
+                        "strip-indent": "2.0.0"
+                    }
+                },
+                "regenerate": {
+                    "version": "1.3.3",
+                    "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+                    "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+                },
+                "regenerator-runtime": {
+                    "version": "0.10.5",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                    "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+                },
+                "regenerator-transform": {
+                    "version": "0.10.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+                    "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "private": "0.1.8"
+                    }
+                },
+                "regex-cache": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+                    "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+                    "requires": {
+                        "is-equal-shallow": "0.1.3"
+                    }
+                },
+                "regexpu-core": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+                    "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+                    "requires": {
+                        "regenerate": "1.3.3",
+                        "regjsgen": "0.2.0",
+                        "regjsparser": "0.1.5"
+                    }
+                },
+                "regjsgen": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                    "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+                },
+                "regjsparser": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                    "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+                    "requires": {
+                        "jsesc": "0.5.0"
+                    },
+                    "dependencies": {
+                        "jsesc": {
+                            "version": "0.5.0",
+                            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                            "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+                        }
+                    }
+                },
+                "remark": {
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/remark/-/remark-8.0.0.tgz",
+                    "integrity": "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==",
+                    "requires": {
+                        "remark-parse": "4.0.0",
+                        "remark-stringify": "4.0.0",
+                        "unified": "6.1.6"
+                    },
+                    "dependencies": {
+                        "remark-parse": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-4.0.0.tgz",
+                            "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
+                            "requires": {
+                                "collapse-white-space": "1.0.3",
+                                "is-alphabetical": "1.0.1",
+                                "is-decimal": "1.0.1",
+                                "is-whitespace-character": "1.0.1",
+                                "is-word-character": "1.0.1",
+                                "markdown-escapes": "1.0.1",
+                                "parse-entities": "1.1.1",
+                                "repeat-string": "1.6.1",
+                                "state-toggle": "1.0.0",
+                                "trim": "0.0.1",
+                                "trim-trailing-lines": "1.1.0",
+                                "unherit": "1.1.0",
+                                "unist-util-remove-position": "1.1.1",
+                                "vfile-location": "2.0.2",
+                                "xtend": "4.0.1"
+                            }
+                        }
+                    }
+                },
+                "remark-parse": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-3.0.1.tgz",
+                    "integrity": "sha1-G5+EGkTY9PvyJGhQJlRZpOs1TIA=",
+                    "requires": {
+                        "collapse-white-space": "1.0.3",
+                        "has": "1.0.1",
+                        "is-alphabetical": "1.0.1",
+                        "is-decimal": "1.0.1",
+                        "is-whitespace-character": "1.0.1",
+                        "is-word-character": "1.0.1",
+                        "markdown-escapes": "1.0.1",
+                        "parse-entities": "1.1.1",
+                        "repeat-string": "1.6.1",
+                        "state-toggle": "1.0.0",
+                        "trim": "0.0.1",
+                        "trim-trailing-lines": "1.1.0",
+                        "unherit": "1.1.0",
+                        "unist-util-remove-position": "1.1.1",
+                        "vfile-location": "2.0.2",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "remark-stringify": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-4.0.0.tgz",
+                    "integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
+                    "requires": {
+                        "ccount": "1.0.2",
+                        "is-alphanumeric": "1.0.0",
+                        "is-decimal": "1.0.1",
+                        "is-whitespace-character": "1.0.1",
+                        "longest-streak": "2.0.2",
+                        "markdown-escapes": "1.0.1",
+                        "markdown-table": "1.1.1",
+                        "mdast-util-compact": "1.0.1",
+                        "parse-entities": "1.1.1",
+                        "repeat-string": "1.6.1",
+                        "state-toggle": "1.0.0",
+                        "stringify-entities": "1.3.1",
+                        "unherit": "1.1.0",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "remove-trailing-separator": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+                    "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+                },
+                "repeat-element": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                    "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+                },
+                "repeat-string": {
+                    "version": "1.6.1",
+                    "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                    "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+                },
+                "repeating": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                    "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+                    "requires": {
+                        "is-finite": "1.0.2"
+                    }
+                },
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+                },
+                "request": {
+                    "version": "2.83.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+                    "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+                    "requires": {
+                        "aws-sign2": "0.7.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.3.1",
+                        "har-validator": "5.0.3",
+                        "hawk": "6.0.2",
+                        "http-signature": "1.2.0",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.17",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "2.1.0",
+                        "qs": "6.5.1",
+                        "safe-buffer": "5.1.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.3",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.2.1"
+                    }
+                },
+                "require-directory": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+                    "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+                },
+                "require-from-string": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+                    "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8="
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+                },
+                "require-uncached": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+                    "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+                    "requires": {
+                        "caller-path": "0.1.0",
+                        "resolve-from": "1.0.1"
+                    },
+                    "dependencies": {
+                        "resolve-from": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+                            "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+                        }
+                    }
+                },
+                "resolve-dir": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+                    "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+                    "requires": {
+                        "expand-tilde": "2.0.2",
+                        "global-modules": "1.0.0"
+                    }
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+                },
+                "restore-cursor": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+                    "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+                    "requires": {
+                        "onetime": "2.0.1",
+                        "signal-exit": "3.0.2"
+                    }
+                },
+                "retry": {
+                    "version": "0.10.1",
+                    "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+                    "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+                },
+                "rimraf": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+                    "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                },
+                "run-async": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+                    "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+                    "requires": {
+                        "is-promise": "2.1.0"
+                    }
+                },
+                "rx": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+                    "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+                },
+                "samsam": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+                    "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+                },
+                "semver": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                    "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+                },
+                "set-immediate-shim": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                    "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+                    "optional": true
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                    "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+                    "requires": {
+                        "shebang-regex": "1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+                },
+                "shelljs": {
+                    "version": "0.5.3",
+                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+                    "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM="
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                    "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+                },
+                "silent-npm-registry-client": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/silent-npm-registry-client/-/silent-npm-registry-client-3.0.1.tgz",
+                    "integrity": "sha1-lTCJbILuMyZqZc37rgPXjTcMl5k=",
+                    "requires": {
+                        "npm-registry-client": "8.5.0",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "sinon": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/sinon/-/sinon-3.3.0.tgz",
+                    "integrity": "sha512-/flfGfIxIRXSvZBHJzIf3iAyGYkmMQq6SQjA0cx9SOuVuq+4ZPPO4LJtH1Ce0Lznax1KSG1U6Dad85wIcSW19w==",
+                    "requires": {
+                        "build": "0.1.4",
+                        "diff": "3.2.0",
+                        "formatio": "1.2.0",
+                        "lodash.get": "4.4.2",
+                        "lolex": "2.3.1",
+                        "native-promise-only": "0.8.1",
+                        "nise": "1.2.0",
+                        "path-to-regexp": "1.7.0",
+                        "samsam": "1.3.0",
+                        "text-encoding": "0.6.4",
+                        "type-detect": "4.0.7"
+                    }
+                },
+                "slash": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+                    "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+                },
+                "slice-ansi": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+                    "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0"
+                    }
+                },
+                "slide": {
+                    "version": "1.1.6",
+                    "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+                    "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+                },
+                "sntp": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+                    "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+                    "requires": {
+                        "hoek": "4.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+                },
+                "source-map-support": {
+                    "version": "0.4.18",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+                    "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+                    "requires": {
+                        "source-map": "0.5.7"
+                    }
+                },
+                "spdx-correct": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                    "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                    "requires": {
+                        "spdx-license-ids": "1.2.2"
+                    }
+                },
+                "spdx-expression-parse": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+                    "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+                },
+                "spdx-license-ids": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                    "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+                },
+                "specificity": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.3.2.tgz",
+                    "integrity": "sha512-Nc/QN/A425Qog7j9aHmwOrlwX2e7pNI47ciwxwy4jOlvbbMHkNNJchit+FX+UjF3IAdiaaV5BKeWuDUnws6G1A=="
+                },
+                "sprintf-js": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                    "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+                },
+                "ssh2": {
+                    "version": "0.4.15",
+                    "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.4.15.tgz",
+                    "integrity": "sha1-B8b0EG2fe26m5N9jbGxT8fmBf/g=",
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "ssh2-streams": "0.0.23"
+                    }
+                },
+                "ssh2-streams": {
+                    "version": "0.0.23",
+                    "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.0.23.tgz",
+                    "integrity": "sha1-ru8wgxu1/Er2qj9tCiYaQTUxYSs=",
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "readable-stream": "1.0.34",
+                        "streamsearch": "0.1.2"
+                    }
+                },
+                "sshpk": {
+                    "version": "1.13.1",
+                    "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                    "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "ssri": {
+                    "version": "4.1.6",
+                    "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
+                    "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                },
+                "stack-trace": {
+                    "version": "0.0.10",
+                    "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+                    "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+                },
+                "state-toggle": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.0.tgz",
+                    "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU="
+                },
+                "streamsearch": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+                    "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                },
+                "stringify-entities": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.1.tgz",
+                    "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
+                    "requires": {
+                        "character-entities-html4": "1.1.1",
+                        "character-entities-legacy": "1.1.1",
+                        "is-alphanumerical": "1.0.1",
+                        "is-hexadecimal": "1.0.1"
+                    }
+                },
+                "stringstream": {
+                    "version": "0.0.5",
+                    "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                    "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+                },
+                "strip-eof": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                    "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+                },
+                "strip-indent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+                    "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+                },
+                "style-search": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+                    "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
+                },
+                "stylelint": {
+                    "version": "8.4.0",
+                    "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-8.4.0.tgz",
+                    "integrity": "sha512-56hPH5mTFnk8LzlEuTWq0epa34fHuS54UFYQidBOFt563RJBNi1nz1F2HK2MoT1X1waq47milvRsRahFCCJs/Q==",
+                    "requires": {
+                        "autoprefixer": "7.2.5",
+                        "balanced-match": "1.0.0",
+                        "chalk": "2.3.0",
+                        "cosmiconfig": "3.1.0",
+                        "debug": "3.1.0",
+                        "execall": "1.0.0",
+                        "file-entry-cache": "2.0.0",
+                        "get-stdin": "5.0.1",
+                        "globby": "7.1.1",
+                        "globjoin": "0.1.4",
+                        "html-tags": "2.0.0",
+                        "ignore": "3.3.7",
+                        "imurmurhash": "0.1.4",
+                        "known-css-properties": "0.5.0",
+                        "lodash": "4.17.4",
+                        "log-symbols": "2.2.0",
+                        "mathml-tag-names": "2.0.1",
+                        "meow": "4.0.0",
+                        "micromatch": "2.3.11",
+                        "normalize-selector": "0.2.0",
+                        "pify": "3.0.0",
+                        "postcss": "6.0.16",
+                        "postcss-html": "0.12.0",
+                        "postcss-less": "1.1.3",
+                        "postcss-media-query-parser": "0.2.3",
+                        "postcss-reporter": "5.0.0",
+                        "postcss-resolve-nested-selector": "0.1.1",
+                        "postcss-safe-parser": "3.0.1",
+                        "postcss-sass": "0.2.0",
+                        "postcss-scss": "1.0.3",
+                        "postcss-selector-parser": "3.1.1",
+                        "postcss-value-parser": "3.3.0",
+                        "resolve-from": "4.0.0",
+                        "specificity": "0.3.2",
+                        "string-width": "2.1.1",
+                        "style-search": "0.1.0",
+                        "sugarss": "1.0.1",
+                        "svg-tags": "1.0.0",
+                        "table": "4.0.2"
+                    },
+                    "dependencies": {
+                        "globby": {
+                            "version": "7.1.1",
+                            "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+                            "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+                            "requires": {
+                                "array-union": "1.0.2",
+                                "dir-glob": "2.0.0",
+                                "glob": "7.1.2",
+                                "ignore": "3.3.7",
+                                "pify": "3.0.0",
+                                "slash": "1.0.0"
+                            }
+                        },
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+                        },
+                        "resolve-from": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+                        }
+                    }
+                },
+                "stylelint-config-recommended": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-1.0.0.tgz",
+                    "integrity": "sha512-wp50rY5A6MWndIIkKNNzJv/S58lTvqQEriS7CXTBN1SwtoY/YjHhCLIOkjundLnUWMvJJska6GnciLbs76UQrA=="
+                },
+                "stylelint-config-standard": {
+                    "version": "17.0.0",
+                    "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-17.0.0.tgz",
+                    "integrity": "sha512-G8jMZ0KsaVH7leur9XLZVhwOBHZ2vdbuJV8Bgy0ta7/PpBhEHo6fjVDaNchyCGXB5sRcWVq6O9rEU/MvY9cQDQ==",
+                    "requires": {
+                        "stylelint-config-recommended": "1.0.0"
+                    }
+                },
+                "sugarss": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz",
+                    "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
+                    "requires": {
+                        "postcss": "6.0.16"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                },
+                "svg-tags": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+                    "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
+                },
+                "table": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+                    "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+                    "requires": {
+                        "ajv": "5.5.2",
+                        "ajv-keywords": "2.1.1",
+                        "chalk": "2.3.0",
+                        "lodash": "4.17.4",
+                        "slice-ansi": "1.0.0",
+                        "string-width": "2.1.1"
+                    }
+                },
+                "tar": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-4.3.2.tgz",
+                    "integrity": "sha512-xq2YLcAiE6/THltmw5cmWkwildoat5hv+VoqSX7qqIs1ELzeR4J59QEetSoSI13Bd3RFSdcar4X/pzElEOy9Ow==",
+                    "requires": {
+                        "chownr": "1.0.1",
+                        "fs-minipass": "1.2.5",
+                        "minipass": "2.2.1",
+                        "minizlib": "1.1.0",
+                        "mkdirp": "0.5.1",
+                        "yallist": "3.0.2"
+                    },
+                    "dependencies": {
+                        "yallist": {
+                            "version": "3.0.2",
+                            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+                            "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+                        }
+                    }
+                },
+                "term-size": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+                    "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+                    "requires": {
+                        "execa": "0.7.0"
+                    }
+                },
+                "test-exclude": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+                    "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+                    "requires": {
+                        "arrify": "1.0.1",
+                        "micromatch": "2.3.11",
+                        "object-assign": "4.1.1",
+                        "read-pkg-up": "1.0.1",
+                        "require-main-filename": "1.0.1"
+                    },
+                    "dependencies": {
+                        "find-up": {
+                            "version": "1.1.2",
+                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                            "requires": {
+                                "path-exists": "2.1.0",
+                                "pinkie-promise": "2.0.1"
+                            }
+                        },
+                        "load-json-file": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                            "requires": {
+                                "graceful-fs": "4.1.11",
+                                "parse-json": "2.2.0",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1",
+                                "strip-bom": "2.0.0"
+                            }
+                        },
+                        "parse-json": {
+                            "version": "2.2.0",
+                            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                            "requires": {
+                                "error-ex": "1.3.1"
+                            }
+                        },
+                        "path-exists": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                            "requires": {
+                                "pinkie-promise": "2.0.1"
+                            }
+                        },
+                        "path-type": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                            "requires": {
+                                "graceful-fs": "4.1.11",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1"
+                            }
+                        },
+                        "read-pkg": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                            "requires": {
+                                "load-json-file": "1.1.0",
+                                "normalize-package-data": "2.4.0",
+                                "path-type": "1.1.0"
+                            }
+                        },
+                        "read-pkg-up": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                            "requires": {
+                                "find-up": "1.1.2",
+                                "read-pkg": "1.1.0"
+                            }
+                        },
+                        "strip-bom": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                            "requires": {
+                                "is-utf8": "0.2.1"
+                            }
+                        }
+                    }
+                },
+                "text-encoding": {
+                    "version": "0.6.4",
+                    "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+                    "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+                },
+                "text-table": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+                    "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+                },
+                "through": {
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                    "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+                },
+                "timespan": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz",
+                    "integrity": "sha1-SQLOBAvRPYRcj1myfp1ZutbzmSk="
+                },
+                "tmp": {
+                    "version": "0.0.33",
+                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+                    "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+                    "requires": {
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "tmpl": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+                    "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+                },
+                "to-fast-properties": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                    "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+                },
+                "topo": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+                    "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+                    "requires": {
+                        "hoek": "4.2.0"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+                    "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                },
+                "traverse": {
+                    "version": "0.6.6",
+                    "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+                    "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+                },
+                "trim": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+                    "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+                },
+                "trim-newlines": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+                    "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+                },
+                "trim-right": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+                    "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+                },
+                "trim-trailing-lines": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
+                    "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ="
+                },
+                "trough": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.1.tgz",
+                    "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y="
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                    "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+                    "optional": true
+                },
+                "type-check": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                    "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+                    "requires": {
+                        "prelude-ls": "1.1.2"
+                    }
+                },
+                "type-detect": {
+                    "version": "4.0.7",
+                    "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.7.tgz",
+                    "integrity": "sha512-4Rh17pAMVdMWzktddFhISRnUnFIStObtUMNGzDwlA6w/77bmGv3aBbRdCmQR6IjzfkTo9otnW+2K/cDRhKSxDA=="
+                },
+                "typedarray": {
+                    "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                    "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+                },
+                "uglify-js": {
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
+                    "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0="
+                },
+                "underscore": {
+                    "version": "1.8.3",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+                },
+                "unherit": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
+                    "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "unified": {
+                    "version": "6.1.6",
+                    "resolved": "https://registry.npmjs.org/unified/-/unified-6.1.6.tgz",
+                    "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
+                    "requires": {
+                        "bail": "1.0.2",
+                        "extend": "3.0.1",
+                        "is-plain-obj": "1.1.0",
+                        "trough": "1.0.1",
+                        "vfile": "2.3.0",
+                        "x-is-function": "1.0.4",
+                        "x-is-string": "0.1.0"
+                    }
+                },
+                "uniq": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+                    "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+                },
+                "unist-util-find-all-after": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.1.tgz",
+                    "integrity": "sha1-TlUSq/734GFnga7Pex7XUcAK+Qg=",
+                    "requires": {
+                        "unist-util-is": "2.1.1"
+                    }
+                },
+                "unist-util-is": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.1.tgz",
+                    "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs="
+                },
+                "unist-util-modify-children": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.1.tgz",
+                    "integrity": "sha1-ZtfmpEnm9nIguXarPLi166w55R0=",
+                    "requires": {
+                        "array-iterate": "1.1.1"
+                    }
+                },
+                "unist-util-remove-position": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz",
+                    "integrity": "sha1-WoXBVV/BugwQG4ZwfRXlD6TIcbs=",
+                    "requires": {
+                        "unist-util-visit": "1.3.0"
+                    }
+                },
+                "unist-util-stringify-position": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz",
+                    "integrity": "sha1-PMvcU2ee7W7PN3fdf14yKcG2qjw="
+                },
+                "unist-util-visit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.0.tgz",
+                    "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
+                    "requires": {
+                        "unist-util-is": "2.1.1"
+                    }
+                },
+                "user-home": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+                    "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                },
+                "uuid": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+                    "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+                },
+                "v8flags": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+                    "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+                    "requires": {
+                        "user-home": "1.1.1"
+                    }
+                },
+                "validate-npm-package-license": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                    "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                    "requires": {
+                        "spdx-correct": "1.0.2",
+                        "spdx-expression-parse": "1.0.4"
+                    }
+                },
+                "validate-npm-package-name": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+                    "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+                    "requires": {
+                        "builtins": "1.0.3"
+                    }
+                },
+                "verror": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                    "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "extsprintf": "1.3.0"
+                    }
+                },
+                "vfile": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+                    "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+                    "requires": {
+                        "is-buffer": "1.1.6",
+                        "replace-ext": "1.0.0",
+                        "unist-util-stringify-position": "1.1.1",
+                        "vfile-message": "1.0.0"
+                    }
+                },
+                "vfile-location": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.2.tgz",
+                    "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU="
+                },
+                "vfile-message": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.0.tgz",
+                    "integrity": "sha512-HPREhzTOB/sNDc9/Mxf8w0FmHnThg5CRSJdR9VRFkD2riqYWs+fuXlj5z8mIpv2LrD7uU41+oPWFOL4Mjlf+dw==",
+                    "requires": {
+                        "unist-util-stringify-position": "1.1.1"
+                    }
+                },
+                "walker": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+                    "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+                    "requires": {
+                        "makeerror": "1.0.11"
+                    }
+                },
+                "which": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+                    "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+                    "requires": {
+                        "isexe": "2.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+                    "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+                    "optional": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                            "optional": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                            "optional": true,
+                            "requires": {
+                                "number-is-nan": "1.0.1"
+                            }
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "optional": true,
+                            "requires": {
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "optional": true,
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            }
+                        }
+                    }
+                },
+                "widest-line": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+                    "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+                    "requires": {
+                        "string-width": "2.1.1"
+                    }
+                },
+                "winston": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+                    "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+                    "requires": {
+                        "async": "1.0.0",
+                        "colors": "1.0.3",
+                        "cycle": "1.0.3",
+                        "eyes": "0.1.8",
+                        "isstream": "0.1.2",
+                        "stack-trace": "0.0.10"
+                    },
+                    "dependencies": {
+                        "async": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+                            "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+                        },
+                        "colors": {
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+                            "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+                        }
+                    }
+                },
+                "wordwrap": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+                    "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                            "requires": {
+                                "number-is-nan": "1.0.1"
+                            }
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "requires": {
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            }
+                        }
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                },
+                "wrench": {
+                    "version": "1.3.9",
+                    "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz",
+                    "integrity": "sha1-bxPsNRRTF+spLKX2UxORskQRFBE="
+                },
+                "write": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+                    "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+                    "requires": {
+                        "mkdirp": "0.5.1"
+                    }
+                },
+                "x-is-function": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/x-is-function/-/x-is-function-1.0.4.tgz",
+                    "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4="
+                },
+                "x-is-string": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+                    "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+                },
+                "xtend": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                    "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+                },
+                "y18n": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                    "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+                },
+                "yargs": {
+                    "version": "8.0.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+                    "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+                    "requires": {
+                        "camelcase": "4.1.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.1.0",
+                        "read-pkg-up": "2.0.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "7.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+                    "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+                    "requires": {
+                        "camelcase": "4.1.0"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "meteor-apm-server",
+    "version": "1.0.8",
+    "description": "Get meteor-apm-server up and running with a stable configuration using MUP",
+    "scripts": {
+        "mup-deploy": "npx mup setup && npx mup deploy",
+        "mup-logs": "npx mup logs",
+        "mup-restart": "npx mup restart"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/lmachens/meteor-apm-server.git"
+    },
+    "author": "lmachens",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/lmachens/meteor-apm-server/issues"
+    },
+    "homepage": "https://github.com/lmachens/meteor-apm-server#readme",
+    "dependencies": {
+        "mup": "1.4.2"
+    }
+}

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,3 @@
+{
+  "metricsLifetime": 604800000,
+}


### PR DESCRIPTION
This repo was great for getting a self-hosted version of Meteor APM up and running, but getting a properly configured server working well took a good deal of effort. During the time I was working through these issues along with @jasongrishkoff, it was clear that the issues would show up for most people attempting to self-host using this repo.

When I found this repo, I was looking for something I could clone, enter my server IP address/domain/ssh key, and hit `mup setup && mup deploy` to get it up and running.

This PR is what I believe is the closest we can currently get to that goal. Using the setup provided via the example `mup.js` config and setup steps in README, I currently have a stable self-hosted APM server that uses HTTPS, uses minimal CPU/disk resources, and does everything I need it to. If I want to update/replace this server, it's a simple matter of running `mup deploy` again and it's reconfigured exactly as I need it.

Using this new guide, somebody can spend ~30 minutes setting up their own fully functional APM server running on an AWS t2.nano instance for a whopping ~$5/month.